### PR TITLE
Added code to get the coverage of a single test method

### DIFF
--- a/framework/bin/d4j/d4j-coverage
+++ b/framework/bin/d4j/d4j-coverage
@@ -140,10 +140,14 @@ if (defined $TEST_SUITE) {
     Utils::extract_test_suite($TEST_SUITE, $test_dir) or die;
     $project->compile_ext_tests($test_dir) or die "Cannot compile extracted test suite!";
     $cov_results = Coverage::coverage_ext($project, $classes, $src_dir, $test_dir, "*.java", $test_log);
+} elsif ($REL_TESTS) {
+    # Compile and run only relevant developer-written tests
+    $project->compile_tests() or die "Cannot compile test suite!";
+    $cov_results = Coverage::coverage($project, $classes, $src_dir, $test_log, $REL_TESTS);
 } else {
     # Compile and run developer-written tests
     $project->compile_tests() or die "Cannot compile test suite!";
-    $cov_results = Coverage::coverage($project, $classes, $src_dir, $test_log, $REL_TESTS);
+    $cov_results = Coverage::coverage($project, $classes, $src_dir, $test_log, undef, $SINGLE_TEST);
 }
 defined $cov_results or die "Couldn't obtain coverage results!";
 

--- a/framework/core/Coverage.pm
+++ b/framework/core/Coverage.pm
@@ -89,7 +89,7 @@ sub coverage {
     if ($relevant_tests) {
         $project->run_relevant_tests($log_file) or return undef;
     } else {
-        $project->run_tests($log_file) or return undef;
+        $project->run_tests($log_file, $single_test) or return undef;
     }
 
 	# Generate coverage report


### PR DESCRIPTION
`framework/bin/d4j/d4j-coverage` script already included the `-t single_test` option to get the coverage of an atomic test method, however there was no code to actually do it.