### PR TITLE
Fixed 'cobertura.aux.classpath' of Closure's bugs

### DIFF
--- a/framework/projects/Closure/Closure.build.xml
+++ b/framework/projects/Closure/Closure.build.xml
@@ -52,7 +52,7 @@ of the checked-out project version.
     <property name="build.home" value="${build.dir}" />
 
     <!-- property needs to be set for coverage to work -->
-    <property name="cobertura.aux.classpath" value="${d4j.workdir}/lib/guava.jar" />
+    <property name="cobertura.aux.classpath" value="${d4j.workdir}/lib/guava.jar:${d4j.workdir}/lib/guava-r06.jar:${d4j.workdir}/lib/google_common_deploy.jar:${d4j.workdir}/lib/json.jar" />
 
     <target name="compile.tests" depends="compile-tests" />
 


### PR DESCRIPTION

`defects4j coverage` script fails for some Closure's bugs due to ClassNotFoundException.

steps to reproduce the issue:
```
$ $D4J_HOME/framework/bin/defects4j checkout -p Closure -v 2f -w Closure-2f
$ cd Closure-2f
$ $D4J_HOME/framework/bin/defects4j coverage -r -i $D4J_HOME/framework/projects/Closure/loaded_classes/2.src
```
(note: `defects4j coverage` does not fail if I do not use '-i $D4J_HOME/framework/projects/Closure/loaded_classes/2.src')

error message:
```
Running ant (compile.tests)................................................ OK
Running ant (coverage.instrument).......................................... FAIL
Buildfile: framework/projects/defects4j.build.xml

rhino:

properties:

init:

compile:

compile-most:

compile-jdk15:

compile:

properties:

compile:

xmlimplsrc-compile:
     [echo] Calling /tmp/D4J/Closure-2f/lib/rhino/xmlimplsrc/build.xml

compile:

compile-all:

compile:

jar:

rhino-jarjar:
   [jarjar] Updating jar: /tmp/D4J/Closure-2f/build/lib/rhino.jar

svnversion:

compile:
    [javac] /tmp/D4J/Closure-2f/build.xml:256: warning: 'includeantruntime' was not set, defaulting to build.sysclasspath=last; set to false for repeatable builds
    [javac] /tmp/D4J/Closure-2f/build.xml:262: warning: 'includeantruntime' was not set, defaulting to build.sysclasspath=last; set to false for repeatable builds
[propertyfile] Updating property file: /tmp/D4J/Closure-2f/build/classes/com/google/javascript/jscomp/parsing/ParserConfig.properties

check.classes.uptodate:

reset.cobertura.ser:

coverage.instrument:
   [delete] Deleting directory /tmp/D4J/Closure-2f/.classes_instrumented
[cobertura-instrument] Cobertura 2.0.3 - GNU GPL License (NO WARRANTY) - See COPYRIGHT file
[cobertura-instrument] Exception in thread "main" java.lang.RuntimeException: Warning detected and failOnError is true
[cobertura-instrument] WARN   instrumentClass, Unable to instrument file /tmp/D4J/Closure-2f/build/classes/com/google/javascript/jscomp/JSModuleGraph.class
[cobertura-instrument] 	at net.sourceforge.cobertura.instrument.CoberturaInstrumenter.instrumentClass(CoberturaInstrumenter.java:126)
[cobertura-instrument] java.lang.RuntimeException: java.lang.ClassNotFoundException: org.json.JSONException	at net.sourceforge.cobertura.instrument.CoberturaInstrumenter.addInstrumentationToSingleClass(CoberturaInstrumenter.java:234)
[cobertura-instrument] 
[cobertura-instrument] 	at net.sourceforge.cobertura.instrument.Main.addInstrumentationToSingleClass(Main.java:298)	at net.sourceforge.cobertura.instrument.CoberturaClassWriter.getCommonSuperClass(CoberturaClassWriter.java:35)
[cobertura-instrument] 	at net.sourceforge.cobertura.instrument.Main.addInstrumentation(Main.java:307)
[cobertura-instrument] 
[cobertura-instrument] 	at net.sourceforge.cobertura.instrument.Main.parseArguments(Main.java:399)	at org.objectweb.asm.ClassWriter.a(Unknown Source)
[cobertura-instrument] 	at net.sourceforge.cobertura.instrument.Main.main(Main.java:421)
[cobertura-instrument] Caused by: java.lang.RuntimeException: java.lang.ClassNotFoundException: org.json.JSONException
[cobertura-instrument] 	at net.sourceforge.cobertura.instrument.CoberturaClassWriter.getCommonSuperClass(CoberturaClassWriter.java:35)
...
BUILD FAILED
framework/projects/defects4j.build.xml:325: Error instrumenting classes. See messages above.
...
Couldn't obtain coverage results! at framework/bin/d4j/d4j-coverage line 148.
Compilation failed in require at framework/bin/defects4j line 155
```

looking at the error message, it seems that class `org.json.JSONException` cannot be found. although there is a .jar file with that missing class (Closure-2f/lib/json.jar), only Closure-2f/lib/guava.jar is used as _auxClasspath_ by Cobertura.

a possible fix to (all) Closure's bugs is to change line
```
<property name="cobertura.aux.classpath" value="${d4j.workdir}/lib/guava.jar" />
```
of $D4J_HOME/framework/projects/Closure/Closure.build.xml file to something like:
```
<property name="cobertura.aux.classpath" value="${d4j.workdir}/lib/guava.jar:${d4j.workdir}/lib/guava-r06.jar:${d4j.workdir}/lib/google_common_deploy.jar:${d4j.workdir}/lib/json.jar" />
```

I've just executed `$ $D4J_HOME/framework/bin/defects4j coverage -r -i ...` on all Closure's bugs, and the instrumentation step is not failing anymore.

PS: Why is not _cobertura.aux.classpath_ the output of `$ $D4J_HOME/framework/bin/defects4j export -p cp.compile`?