### PR TITLE
Workaround to run two or more Gradle instances at the same time without having any timeout error

### DIFF
--- a/framework/core/Project/Mockito.pm
+++ b/framework/core/Project/Mockito.pm
@@ -140,4 +140,12 @@ sub _build_dir_map {
     $self->{_dir_map}=$cache;
 }
 
+sub _ant_call {
+    @_ >= 2 or die $ARG_ERROR;
+    my ($self, $target, $option_str, $log_file) =  @_;
+
+    $ENV{'GRADLE_USER_HOME'} = "$self->{prog_root}/.gradle_local_home";
+    return $self->SUPER::_ant_call($target, $option_str, $log_file);
+}
+
 1;


### PR DESCRIPTION
When two or more Gradle instances are executed at the same time, and because  by default every single Gradle instance share the same $USER/.gradle directory, a timeout like the following one could occur:
```
...
> Could not resolve all dependencies for configuration ':classpath'.
  > Timeout waiting to lock artifact cache (~/.gradle/caches/modules-2). It is currently in use by another Gradle instance.
    Owner PID: 20967
    Our PID: 26273
    Owner Operation: resolve configuration ':classpath'
    Our operation: resolve configuration ':classpath'
    Lock file: ~/.gradle/caches/modules-2/modules-2.lock
...
```
This issue has been reported [here](https://issues.gradle.org/browse/GRADLE-1991) and [here](https://issues.gradle.org/browse/GRADLE-3106), but is not fixed (or at least marked as fixed) yet.
So, an obvious solution/workaround to this issue is to guarantee that two Gradle instances do not share the same .gradle directory. Here some attempts to address the lock issue.

### 1. Exporting the environment variable GRADLE_USER_HOME

Adding:
```
<env key="GRADLE_USER_HOME" value="${basedir}/.gradle-local-home"/>
```
to each `exec` of targets `gradle.compile`, `gradle.compile.tests`, and `gradle.compile.mutants` of `framework/projects/Mockito.build.xml` file, forces each Gradle execution to use `${basedir}/.gradle-local-home` as user directory. However, at some point the default directory, i.e., $USER/.gradle was also created and used. (It might be that some sub-gradle process is not affected by that environment variable.)

### 2. Exporting GRADLE_OPTS
```
<env key="GRADLE_OPTS" value="-Dgradle.user.home=${basedir}/.gradle-local-home"/>
```
Rather than exporting GRADLE_USER_HOME, gradle.user.home can defined using environment variable GRADLE_OPTS. However, the outcome seems to be the same, both `${basedir}/.gradle-local-home` and $USER/.gradle directories were created and used.

### 3. Adding an extra argument to gradlew call
```
<arg value="--gradle-user-home=${basedir}/.gradle-local-home">
```
But like the previous two attempts, both directories were created and used.

### 4. Exporting the environment variable GRADLE_USER_HOME before calling any command

If the GRADLE_USER_HOME variable is exported before executing any command (see commit), **all** Gradle commands are forced to use it. As each working directory will contain a _private_ and local Gradle home directory, timeouts should not happen again.


@rjust, let me know what do you think about this workaround? And whether my Perl code meets your standards... :smiley: 