### PR TITLE
Fix Mockito's test runners

### DIFF
--- a/framework/core/Project.pm
+++ b/framework/core/Project.pm
@@ -889,6 +889,18 @@ sub lookup {
 
 =pod
 
+  $project->lookup_revision_id(revision)
+
+Delegate to the L<VCS> backend.
+
+=cut
+sub lookup_revision_id {
+    my ($self, $revision) = @_;
+    return $self->{_vcs}->lookup_revision_id($revision);
+}
+
+=pod
+
   $project->num_revision_pairs()
 
 Delegate to the L<VCS> backend.

--- a/framework/core/Project/Mockito.pm
+++ b/framework/core/Project/Mockito.pm
@@ -63,6 +63,13 @@ sub _post_checkout {
     #
     # Post-checkout tasks include, for instance, providing proper build files,
     # fixing compilation errors, etc.
+
+    # Fix Mockito's test runners
+    my $id = $vcs->lookup_revision_id($revision);
+    my $mockito_junit_runner_patch_file = "$SCRIPT_DIR/projects/$PID/mockito_test_runners.patch";
+    if ($id == 16 || $id == 17 || ($id >= 34 && $id <= 38)) {
+        $vcs->apply_patch($work_dir, "$mockito_junit_runner_patch_file") or confess("Couldn't apply patch ($mockito_junit_runner_patch_file): $!");
+    }
 }
 
 #

--- a/framework/core/Project/Time.pm
+++ b/framework/core/Project/Time.pm
@@ -71,24 +71,16 @@ sub _post_checkout {
     }
 
     # Check for a broken-build-revision
-    my $id = $self->rev_lookup($revision_id); # TODO: very ugly.
+    my $id = $self->lookup_revision_id($revision_id); # TODO: very ugly.
     my $filename = "${SCRIPT_DIR}/projects/${PID}/broken-builds/build-${id}.xml";
     if (-e $filename) {
         system ("cp $filename $work_dir/build.xml");
     }
 }
 
-sub rev_lookup {
-    my ($self, $revision) = @_;
-    my @answer = grep {$self->lookup($_ . "f") eq $revision ||
-                       $self->lookup($_ . "b") eq $revision} $self->get_version_ids();
-    return -1 unless scalar(@answer) > 0;
-    return $answer[0];
-}
-
 sub export_diff {
     my ($self, $rev1, $rev2, $out_file, $path) = @_;
-    if ($self->rev_lookup($rev2) >= 22) {
+    if ($self->lookup_revision_id($rev2) >= 22) {
         # path is an optional argument
         $path = "JodaTime/" . ($path//"");
     }
@@ -97,7 +89,7 @@ sub export_diff {
 
 sub diff {
     my ($self, $rev1, $rev2, $path) = @_;
-    if ($self->rev_lookup($rev2) >= 22) {
+    if ($self->lookup_revision_id($rev2) >= 22) {
         # path is an optional argument
         $path = "JodaTime/" . ($path//"");
     }

--- a/framework/core/Vcs.pm
+++ b/framework/core/Vcs.pm
@@ -171,6 +171,22 @@ sub lookup {
 
 =pod
 
+  $vcs->lookup_revision_id(revision)
+
+Returns the C<revision_id> for the given revision number or hash.
+
+=cut
+sub lookup_revision_id {
+    @_ == 2 or die $ARG_ERROR;
+    my ($self, $revision) = @_;
+    my @answer = grep {$self->lookup($_ . "f") eq $revision ||
+                       $self->lookup($_ . "b") eq $revision} $self->get_version_ids();
+    return -1 unless scalar(@answer) > 0;
+    return $answer[0];
+}
+
+=pod
+
   $vcs->num_revision_pairs()
 
 Returns the number of revision pairs in the C<commit-db>.

--- a/framework/projects/Mockito/mockito_test_runners.patch
+++ b/framework/projects/Mockito/mockito_test_runners.patch
@@ -1,0 +1,105 @@
+diff --git a/src/org/mockito/internal/runners/JUnit44RunnerImpl.java b/src/org/mockito/internal/runners/JUnit44RunnerImpl.java
+index 3f435c0..8a40d04 100644
+--- a/src/org/mockito/internal/runners/JUnit44RunnerImpl.java
++++ b/src/org/mockito/internal/runners/JUnit44RunnerImpl.java
+@@ -15,7 +15,7 @@ import org.mockito.internal.runners.util.FrameworkUsageValidator;
+ @SuppressWarnings("deprecation")
+ public class JUnit44RunnerImpl implements RunnerImpl {
+ 
+-    Runner runner;
++    JUnit4ClassRunner runner;
+ 
+     public JUnit44RunnerImpl(Class<?> klass) throws InitializationError {
+         this.runner = new JUnit4ClassRunner(klass) {
+@@ -38,4 +38,8 @@ public class JUnit44RunnerImpl implements RunnerImpl {
+     public Description getDescription() {
+         return runner.getDescription();
+     }
+-}
+\ No newline at end of file
++    public void filter(org.junit.runner.manipulation.Filter filter) throws org.junit.runner.manipulation.NoTestsRemainException {
++        // filter is required because without it UnrootedTests show up in Eclipse
++        runner.filter(filter);
++    }
++}
+diff --git a/src/org/mockito/internal/runners/JUnit45AndHigherRunnerImpl.java b/src/org/mockito/internal/runners/JUnit45AndHigherRunnerImpl.java
+index c7bf194..33ca220 100644
+--- a/src/org/mockito/internal/runners/JUnit45AndHigherRunnerImpl.java
++++ b/src/org/mockito/internal/runners/JUnit45AndHigherRunnerImpl.java
+@@ -16,7 +16,7 @@ import org.mockito.internal.runners.util.FrameworkUsageValidator;
+ 
+ public class JUnit45AndHigherRunnerImpl implements RunnerImpl {
+ 
+-    private Runner runner;
++    private BlockJUnit4ClassRunner runner;
+ 
+     public JUnit45AndHigherRunnerImpl(Class<?> klass) throws InitializationError {
+         runner = new BlockJUnit4ClassRunner(klass) {
+@@ -39,4 +39,9 @@ public class JUnit45AndHigherRunnerImpl implements RunnerImpl {
+     public Description getDescription() {
+         return runner.getDescription();
+     }
+-}
+\ No newline at end of file
++    @Override
++    public void filter(org.junit.runner.manipulation.Filter filter) throws org.junit.runner.manipulation.NoTestsRemainException {
++        // filter is required because without it UnrootedTests show up in Eclipse
++        runner.filter(filter);
++    }
++}
+diff --git a/src/org/mockito/internal/runners/RunnerImpl.java b/src/org/mockito/internal/runners/RunnerImpl.java
+index 7294ce1..cdd88cb 100644
+--- a/src/org/mockito/internal/runners/RunnerImpl.java
++++ b/src/org/mockito/internal/runners/RunnerImpl.java
+@@ -11,10 +11,10 @@ import org.junit.runner.notification.RunNotifier;
+  * I'm using this surrogate interface to hide internal Runner implementations.
+  * Surrogate cannot be used with &#064;RunWith therefore it is less likely clients will use interal runners.
+  */
+-public interface RunnerImpl {
++public interface RunnerImpl extends org.junit.runner.manipulation.Filterable {
+ 
+     void run(RunNotifier notifier);
+ 
+     Description getDescription();
+ 
+-}
+\ No newline at end of file
++}
+diff --git a/src/org/mockito/runners/MockitoJUnitRunner.java b/src/org/mockito/runners/MockitoJUnitRunner.java
+index 3cf90f0..142fa31 100644
+--- a/src/org/mockito/runners/MockitoJUnitRunner.java
++++ b/src/org/mockito/runners/MockitoJUnitRunner.java
+@@ -46,7 +46,7 @@ import java.lang.reflect.InvocationTargetException;
+  * }
+  * </pre>
+  */
+-public class MockitoJUnitRunner extends Runner {
++public class MockitoJUnitRunner extends Runner implements org.junit.runner.manipulation.Filterable {
+ 
+     private final RunnerImpl runner;
+ 
+@@ -63,4 +63,8 @@ public class MockitoJUnitRunner extends Runner {
+     public Description getDescription() {
+         return runner.getDescription();
+     }
+-}
+\ No newline at end of file
++    public void filter(org.junit.runner.manipulation.Filter filter) throws org.junit.runner.manipulation.NoTestsRemainException {
++        // filter is required because without it UnrootedTests show up in Eclipse
++        runner.filter(filter);
++    }
++}
+diff --git a/test/org/mockito/runners/ConsoleSpammingMockitoJUnitRunnerTest.java b/test/org/mockito/runners/ConsoleSpammingMockitoJUnitRunnerTest.java
+index 0ace37b..3ff5678 100644
+--- a/test/org/mockito/runners/ConsoleSpammingMockitoJUnitRunnerTest.java
++++ b/test/org/mockito/runners/ConsoleSpammingMockitoJUnitRunnerTest.java
+@@ -198,6 +198,7 @@ public class ConsoleSpammingMockitoJUnitRunnerTest extends TestBase {
+         }
+ 
+         public void run(RunNotifier notifier) {}
++        public void filter(org.junit.runner.manipulation.Filter filter) throws org.junit.runner.manipulation.NoTestsRemainException {}
+ 
+     }
+-}
+\ No newline at end of file
++}


### PR DESCRIPTION
Some Mockito's test classes are annotated with `@RunWith(MockitoJUnitRunner.class)` which means they are executed using a custom JUnit runner instead of the default one. This allows, for example, the initialization of Mocks without explicitly calling the init functions. However, Mockito's test runners of bugs Mockito-16, 17, 34, 35, 36, 37, 38 is buggy and it does not allow the execution of single test methods of test classes that are annotated with `@RunWith(MockitoJUnitRunner.class)`. In [20th of January/2010](https://github.com/mockito/mockito/commit/f2b938d32f111984dddb54e35d6243143691d1a9), _szczepiq_ fixed MockitoJUnitRunner and the commit message was:
```
Fixed issue 109
Unrooted tests no longer show up in Eclipse when running single test
Thanks for the patch & great job!!!
```
As Mockito's bugs 16, 17, 34, 35, 36, 37, 38 were fixed before 20/01/2010
```
Mockito-1,Wed May 20 18:40:11 2015
Mockito-2,Fri May 8 21:08:46 2015
Mockito-3,Wed May 20 20:37:52 2015
Mockito-4,Fri Apr 17 11:45:21 2015
Mockito-5,Fri Jan 2 19:09:45 2015
Mockito-6,Mon Dec 15 23:30:26 2014
Mockito-7,Wed Dec 31 17:37:36 2014
Mockito-8,Mon Dec 15 14:56:02 2014
Mockito-9,Sat Nov 22 10:36:41 2014
Mockito-10,Fri Oct 10 02:44:43 2014
Mockito-11,Fri Sep 26 16:01:47 2014
Mockito-12,Sun May 16 16:21:00 2010
Mockito-13,Tue May 11 19:01:47 2010
Mockito-14,Wed Mar 17 20:18:21 2010
Mockito-15,Wed Nov 3 12:36:41 2010
**Mockito-16,Sun Nov 22 14:35:32 2009**
**Mockito-17,Sat Nov 21 23:04:52 2009**
Mockito-18,Wed Jun 3 16:01:52 2015
Mockito-19,Wed Jun 3 00:52:12 2015
Mockito-20,Sun Feb 15 20:09:35 2015
Mockito-21,Mon Nov 17 00:42:03 2014
Mockito-22,Sat Apr 12 16:09:33 2014
Mockito-23,Thu Jan 16 09:37:53 2014
Mockito-24,Wed Jan 8 13:13:43 2014
Mockito-25,Thu Oct 25 21:49:58 2012
Mockito-26,Sat Jun 30 15:06:31 2012
Mockito-27,Sat Oct 1 17:09:50 2011
Mockito-28,Mon Dec 20 20:11:06 2010
Mockito-29,Thu Nov 18 17:54:14 2010
Mockito-30,Fri Nov 5 18:55:32 2010
Mockito-31,Fri Nov 5 18:33:46 2010
Mockito-32,Thu Sep 2 18:23:03 2010
Mockito-33,Tue Jun 22 05:32:13 2010
**Mockito-34,Fri Dec 11 20:30:44 2009**
**Mockito-35,Mon Nov 9 22:36:06 2009**
**Mockito-36,Sun Nov 8 20:07:50 2009**
**Mockito-37,Sun Nov 8 19:32:25 2009**
**Mockito-38,Thu Jul 9 11:23:58 2009**
```
they do not contain the [fix 109](https://github.com/mockito/mockito/commit/f2b938d32f111984dddb54e35d6243143691d1a9). So, here I propose a post_checkout step (only for the affected Mockito's bugs) which applies a minimal version of the [original patch](https://github.com/mockito/mockito/commit/f2b938d32f111984dddb54e35d6243143691d1a9) in order to fix Mockito's test runners.