### PR TITLE
Updated 'fix_test_suite.pl' script to remove uncompilable test cases

### DIFF
--- a/framework/test/resources/input/foo/bar/InvalidImport.java
+++ b/framework/test/resources/input/foo/bar/InvalidImport.java
@@ -1,0 +1,12 @@
+package foo.bar;
+
+import non.existing.classtoimport;
+import org.junit.Test;
+
+public class InvalidImport {
+
+  @Test
+  public void dummy() {
+    // empty
+  }
+}

--- a/framework/test/resources/input/foo/bar/UnitTestsWithCompilationIssues.java
+++ b/framework/test/resources/input/foo/bar/UnitTestsWithCompilationIssues.java
@@ -1,0 +1,17 @@
+package foo.bar;
+
+import org.junit.Test;
+
+public class UnitTestsWithCompilationIssues {
+
+  @Test
+  public void test0() {
+    String str = new String();
+    str = 123456789;
+  }
+
+  @Test
+  public void test1() {
+    assertTrue(123456789 == 123456789)
+  }
+}

--- a/framework/test/resources/input/foo/bar/ValidTestClass.java
+++ b/framework/test/resources/input/foo/bar/ValidTestClass.java
@@ -1,0 +1,20 @@
+package foo.bar;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class ValidTestClass {
+
+  @Test
+  public void test0() {
+    String str = new String("123456789");
+    assertEquals("123456789", str);
+  }
+
+  @Test
+  public void test1() {
+    assertTrue(123456789 == 123456789);
+  }
+}

--- a/framework/test/resources/output/foo/bar/InvalidImport.java.broken
+++ b/framework/test/resources/output/foo/bar/InvalidImport.java.broken
@@ -1,0 +1,12 @@
+package foo.bar;
+
+import non.existing.classtoimport;
+import org.junit.Test;
+
+public class InvalidImport {
+
+  @Test
+  public void dummy() {
+    // empty
+  }
+}

--- a/framework/test/resources/output/foo/bar/UnitTestsWithCompilationIssues.java
+++ b/framework/test/resources/output/foo/bar/UnitTestsWithCompilationIssues.java
@@ -1,0 +1,23 @@
+package foo.bar;
+
+import org.junit.Test;
+
+public class UnitTestsWithCompilationIssues {
+
+  @Test
+  public void test0() {}
+// Defects4J: flaky method
+//   @Test
+//   public void test0() {
+//     String str = new String();
+//     str = 123456789;
+//   }
+
+  @Test
+  public void test1() {}
+// Defects4J: flaky method
+//   @Test
+//   public void test1() {
+//     assertTrue(123456789 == 123456789)
+//   }
+}

--- a/framework/test/resources/output/foo/bar/UnitTestsWithCompilationIssues.java.bak
+++ b/framework/test/resources/output/foo/bar/UnitTestsWithCompilationIssues.java.bak
@@ -1,0 +1,17 @@
+package foo.bar;
+
+import org.junit.Test;
+
+public class UnitTestsWithCompilationIssues {
+
+  @Test
+  public void test0() {
+    String str = new String();
+    str = 123456789;
+  }
+
+  @Test
+  public void test1() {
+    assertTrue(123456789 == 123456789)
+  }
+}

--- a/framework/test/resources/output/foo/bar/ValidTestClass.java
+++ b/framework/test/resources/output/foo/bar/ValidTestClass.java
@@ -1,0 +1,20 @@
+package foo.bar;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class ValidTestClass {
+
+  @Test
+  public void test0() {
+    String str = new String("123456789");
+    assertEquals("123456789", str);
+  }
+
+  @Test
+  public void test1() {
+    assertTrue(123456789 == 123456789);
+  }
+}

--- a/framework/test/test_fix_test_suite.sh
+++ b/framework/test/test_fix_test_suite.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+################################################################################
+#
+# This script tests the util/fix_test_suite.pl script.
+#
+################################################################################
+
+HERE=$(cd `dirname $0` && pwd)
+
+# Import helper subroutines and variables, and init Defects4J
+source "$HERE/test.include" || exit 1
+init
+
+_check_output() {
+  local USAGE="Usage: _check_output <actual> <expected>"
+  if [ "$#" != 2 ]; then
+    echo "$USAGE" >&2
+    return 1
+  fi
+
+  local actual="$1"
+  local expected="$2"
+
+  cmp --silent "$expected" "$actual" || die "'$actual' is not equal to '$expected'!"
+  return 0
+}
+
+pid="Math" # any pid-bid should work
+bid="1b"
+
+# Create a directory for test suites
+suites_dir="$TMP_DIR/test_suites_dir"
+rm -rf "$suites_dir"
+mkdir -p "$suites_dir"
+
+# Create a .tar.bz2 file with all test suites
+pushd . > /dev/null 2>&1
+cd "$HERE/resources/input"
+  tar_bz2_file="$suites_dir/$pid-$bid-test.0.tar.bz2"
+  tar -jcvf "$tar_bz2_file" \
+    foo/bar/InvalidImport.java \
+    foo/bar/UnitTestsWithCompilationIssues.java \
+    foo/bar/ValidTestClass.java || die "Was not possible to create '$tar_bz2_file' file!"
+popd > /dev/null 2>&1
+
+# Fix test suites
+fix_test_suite.pl -p "$pid" -d "$suites_dir" -v "$bid" || die "Script 'fix_test_suite.pl' has failed!"
+
+tar -jxvf "$tar_bz2_file" -C "$suites_dir"
+
+# Check output of 'fix_test_suite.pl' script
+
+_check_output \
+  "$HERE/resources/output/foo/bar/InvalidImport.java.broken" \
+  "$suites_dir/foo/bar/InvalidImport.java.broken"
+
+_check_output \
+  "$HERE/resources/output/foo/bar/UnitTestsWithCompilationIssues.java" \
+  "$suites_dir/foo/bar/UnitTestsWithCompilationIssues.java"
+
+_check_output \
+  "$HERE/resources/output/foo/bar/UnitTestsWithCompilationIssues.java.bak" \
+  "$suites_dir/foo/bar/UnitTestsWithCompilationIssues.java.bak"
+
+_check_output \
+  "$HERE/resources/output/foo/bar/ValidTestClass.java" \
+  "$suites_dir/foo/bar/ValidTestClass.java"
+
+rm -rf "$suites_dir"
+
+# EOF
+


### PR DESCRIPTION
Hi @rjust,

(As you know) The current version of 'fix_test_suite.pl' script removes a source file if there is a single compilation issue. Which means that no matter how many test cases a suite has, all are discarded, even if there is only one test case that does not compile.

I have been generating test cases for a while and I noticed that most of (if not all) compilation issues are test related and not suite related. So, here I purpose we change 'fix_test_suite.pl' script to remove uncompilable test cases (if the compilation issues are indeed test related). If there are compilation issues that are not test-related (like wrong imports or problems with any super class, etc) it applies the current behavior, i.e., it removes the source file.

Please let me know what do you think about this PR. Any feedback will be appreciated. :-)

--
Cheers,
Jose