### PR TITLE
JUnit task vs. Exec task

### DIFF
--- a/framework/projects/defects4j.build.xml
+++ b/framework/projects/defects4j.build.xml
@@ -99,11 +99,11 @@ project-specific build file ("project_id"/"project_id".build.xml) for the
     Run developer-written tests
 -->
     <target name="run.dev.tests" depends="compile.tests,update.all.tests" description="Run unit tests">
-        <junit printsummary="yes" haltonfailure="no" haltonerror="no" fork="no" showOutput="true">
-            <classpath>
+        <!--<junit printsummary="yes" haltonfailure="no" haltonerror="no" fork="no" showOutput="true">
+            <classpath>-->
                 <!-- Make sure that instrumented classes appear at the beginning of the
                      classpath -->
-                <pathelement location="${d4j.dir.classes.instrumented}" />
+                <!--<pathelement location="${d4j.dir.classes.instrumented}" />
                 <pathelement path="${formatter.jar}" />
                 <pathelement path="${cobertura.jar}" />
                 <path refid="d4j.test.classpath"/>
@@ -115,7 +115,15 @@ project-specific build file ("project_id"/"project_id".build.xml) for the
             <batchtest unless="test.entry.class">
                 <fileset refid="all.manual.tests" />
             </batchtest>
-        </junit>
+        </junit>-->
+        <!-- FIXME currently it only works with "-t" option -->
+        <pathconvert property="cp.test" refid="d4j.test.classpath" />
+        <exec executable="java" failonerror="false" failifexecutionfails="true" output="${OUTFILE}">
+          <arg value="-cp" />
+          <arg value="${d4j.dir.classes.instrumented}:${formatter.jar}:${cobertura.jar}:${cp.test}" />
+          <arg value="edu.washington.cs.mut.testrunner.SingleTestRunner" />
+          <arg value="${test.entry.class}::${test.entry.method}" />
+        </exec>
         <!-- fail build in case we are running all classes, but there are none in the fileset -->
         <if> <not> <isset property="test.entry.class" /> </not> <then>
             <pathconvert refid="all.manual.tests" property="fileset.notempty" setonempty="false" />


### PR DESCRIPTION
Hi @rjust,

Here my first iteration to address issue #42. Known limitations:
- currently, only the `-t` option of `$D4J_HOME/framework/bin/defects4j test` works, as I've no clue how to get the test class if not specified by `-Dtest.entry.class`.
- whether there are 0 or 1000 failing test cases the outcome of the exec task is not integrated with D4J. (currently, the only way to know if a the test case failed is by looking at the 'failing_tests' file).


--
Cheers,
Jose