### PR TITLE
add quotes to init.sh script to avoid errors when a path name has whitesapce

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -16,18 +16,17 @@ if ! wget --version > /dev/null 2>&1; then
 fi
 
 # Directories for project repositories and external libraries
-BASE=$(cd $(dirname $0); pwd)
+BASE="$(cd $(dirname $0); pwd)"
 DIR_REPOS="$BASE/project_repos"
 DIR_LIB_GEN="$BASE/framework/lib/test_generation/generation"
 DIR_LIB_RT="$BASE/framework/lib/test_generation/runtime"
-mkdir -p $DIR_LIB_GEN
-mkdir -p $DIR_LIB_RT
+mkdir -p "$DIR_LIB_GEN" && mkdir -p "$DIR_LIB_RT"
 
 #
 # Download project repositories if necessary
 #
 echo "Setting up project repositories ... "
-cd $DIR_REPOS && ./get_repos.sh
+cd "$DIR_REPOS" && ./get_repos.sh
 
 #
 # Download Major
@@ -37,9 +36,9 @@ echo "Setting up Major ... "
 MAJOR_VERSION="1.3.1"
 MAJOR_URL="http://mutation-testing.org/downloads"
 MAJOR_ZIP="major-${MAJOR_VERSION}_jre7.zip"
-cd $BASE && wget -nv -N $MAJOR_URL/$MAJOR_ZIP \
-         && unzip -o $MAJOR_ZIP > /dev/null \
-         && rm $MAJOR_ZIP \
+cd "$BASE" && wget -nv -N "$MAJOR_URL/$MAJOR_ZIP" \
+         && unzip -o "$MAJOR_ZIP" > /dev/null \
+         && rm "$MAJOR_ZIP" \
          && cp major/bin/.ant major/bin/ant
 
 #
@@ -51,13 +50,13 @@ EVOSUITE_VERSION="0.2.0"
 EVOSUITE_URL="http://www.evosuite.org/files"
 EVOSUITE_JAR="evosuite-${EVOSUITE_VERSION}.jar"
 EVOSUITE_RT_JAR="evosuite-standalone-runtime-${EVOSUITE_VERSION}.jar"
-cd $DIR_LIB_GEN && [ ! -f $EVOSUITE_JAR ] \
-                && wget -nv $EVOSUITE_URL/$EVOSUITE_JAR
-cd $DIR_LIB_RT  && [ ! -f $EVOSUITE_RT_JAR ] \
-                && wget -nv $EVOSUITE_URL/$EVOSUITE_RT_JAR
+cd "$DIR_LIB_GEN" && [ ! -f "$EVOSUITE_JAR" ] \
+                && wget -nv "$EVOSUITE_URL/$EVOSUITE_JAR"
+cd "$DIR_LIB_RT"  && [ ! -f "$EVOSUITE_RT_JAR" ] \
+                && wget -nv "$EVOSUITE_URL/$EVOSUITE_RT_JAR"
 # Set symlinks for the supported version of EvoSuite
-ln -sf $DIR_LIB_GEN/$EVOSUITE_JAR $DIR_LIB_GEN/evosuite-current.jar
-ln -sf $DIR_LIB_RT/$EVOSUITE_RT_JAR $DIR_LIB_RT/evosuite-rt.jar
+ln -sf "$DIR_LIB_GEN/$EVOSUITE_JAR $DIR_LIB_GEN/evosuite-current.jar"
+ln -sf "$DIR_LIB_RT/$EVOSUITE_RT_JAR $DIR_LIB_RT/evosuite-rt.jar"
 
 #
 # Download Randoop
@@ -67,10 +66,10 @@ echo "Setting up Randoop ... "
 RANDOOP_VERSION="3.1.0"
 RANDOOP_URL="https://github.com/randoop/randoop/releases/download/v${RANDOOP_VERSION}"
 RANDOOP_JAR="randoop-all-${RANDOOP_VERSION}.jar"
-cd $DIR_LIB_GEN && [ ! -f $RANDOOP_JAR ] \
-                && wget -nv $RANDOOP_URL/$RANDOOP_JAR
+cd "$DIR_LIB_GEN" && [ ! -f "$RANDOOP_JAR" ] \
+                && wget -nv "$RANDOOP_URL/$RANDOOP_JAR"
 # Set symlink for the supported version of Randoop
-ln -sf $DIR_LIB_GEN/$RANDOOP_JAR $DIR_LIB_GEN/randoop-current.jar
+ln -sf "$DIR_LIB_GEN/$RANDOOP_JAR $DIR_LIB_GEN/randoop-current.jar"
 
 echo
 echo "Defects4J successfully initialized."


### PR DESCRIPTION
Always use quote when using variables in shell