### PR TITLE
fix documentation in run_bug_detection.pl

### DIFF
--- a/framework/bin/run_bug_detection.pl
+++ b/framework/bin/run_bug_detection.pl
@@ -191,7 +191,7 @@ Examples:
 
 =over 4
 
-=item * F<Lang-11f-randoop.1.tar.bz2 (equal to Lang-1-randoop.tar.bz2)>
+=item * F<Lang-11f-randoop.1.tar.bz2 (equal to Lang-11f-randoop.tar.bz2)>
 
 =item * F<Lang-11b-randoop.2.tar.bz2>
 


### PR DESCRIPTION
According to information given here, test suite number is optional:
project_id-version_id-test_suite_src(\.test_id)?\.tar\.bz2