### PR TITLE
Make Gradle dependencies available offline (fix #182)

### DIFF
--- a/framework/core/Constants.pm
+++ b/framework/core/Constants.pm
@@ -195,6 +195,10 @@ our $GRADLE_LOCAL_HOME_DIR = ".gradle_local_home";
         or die("Couldn't find test generation tools! Did you (re)run 'defects4j/init.sh'?\n\n");
 -d "$BUILD_SYSTEMS_LIB_DIR"
         or die("Couldn't find build system tools! Did you (re)run 'defects4j/init.sh'?\n\n");
+-d "$BUILD_SYSTEMS_LIB_DIR/gradle/dists"
+        or die("Couldn't find gradle distributions! Did you (re)run 'defects4j/init.sh'?\n\n");
+-d "$BUILD_SYSTEMS_LIB_DIR/gradle/deps"
+        or die("Couldn't find gradle dependencies! Did you (re)run 'defects4j/init.sh'?\n\n");
 
 # Add script and core directory to @INC
 unshift(@INC, $CORE_DIR);

--- a/framework/core/Constants.pm
+++ b/framework/core/Constants.pm
@@ -161,17 +161,25 @@ The directory of the libraries of the build system tools (I<C<LIB_DIR>/build_sys
 =cut
 our $BUILD_SYSTEMS_LIB_DIR = ($ENV{'BUILD_SYSTEMS_LIB_DIR'} // "$LIB_DIR/build_systems");
 
-
 =pod
 
 =item C<D4J_BUILD_FILE>
 
 The top-level (ant) build file (I<C<SCRIPT_DIR>/projects/defects4j.build.xml>)
 
+=cut
+our $D4J_BUILD_FILE = ($ENV{'D4J_BUILD_FILE'} or "$SCRIPT_DIR/projects/defects4j.build.xml");
+
+=pod
+
+=item C<GRADLE_LOCAL_HOME_DIR>
+
+The directory name of the local gradle repository (.gradle_local_home).
+
 =back
 
 =cut
-our $D4J_BUILD_FILE = ($ENV{'D4J_BUILD_FILE'} or "$SCRIPT_DIR/projects/defects4j.build.xml");
+our $GRADLE_LOCAL_HOME_DIR = ".gradle_local_home";
 
 #
 # Check whether Defects4J has been properly initialized:
@@ -238,6 +246,8 @@ $REPO_DIR
 $D4J_TMP_DIR
 
 $D4J_BUILD_FILE
+
+$GRADLE_LOCAL_HOME_DIR
 
 $ARG_ERROR
 $ABSTRACT_METHOD

--- a/framework/core/Project/Mockito.pm
+++ b/framework/core/Project/Mockito.pm
@@ -79,11 +79,11 @@ sub _post_checkout {
     open(PROP, "<$prop") or return;
     my @tmp;
     while (<PROP>) {
-        if (/(distributionUrl=).*\/(gradle-2.*)/) {
-            s/(distributionUrl=).*\/(gradle-.*)/$1file\\:$lib_dir\/gradle-2.2.1-all.zip/g;
-        } else {
-            s/(distributionUrl=).*\/(gradle-.*)/$1file\\:$lib_dir\/gradle-1.12-bin.zip/g;
-        }
+        # Replace the online url, e.g.,
+        # https\://services.gradle.org/distributions/gradle-2.4-all.zip
+        # with a local one, e.g.,
+        # file\\:Constants::$BUILD_SYSTEMS_LIB_DIR/gradle/dists/gradle-2.4-all.zip
+        s/(distributionUrl=).*\/(gradle-.*)/$1file\\:$lib_dir\/$2/g;
         push(@tmp, $_);
     }
     close(PROP);

--- a/framework/core/Project/Mockito.pm
+++ b/framework/core/Project/Mockito.pm
@@ -79,11 +79,11 @@ sub _post_checkout {
     open(PROP, "<$prop") or return;
     my @tmp;
     while (<PROP>) {
-        # Replace the online url, e.g.,
-        # https\://services.gradle.org/distributions/gradle-2.4-all.zip
-        # with a local one, e.g.,
-        # file\\:Constants::$BUILD_SYSTEMS_LIB_DIR/gradle/dists/gradle-2.4-all.zip
-        s/(distributionUrl=).*\/(gradle-.*)/$1file\\:$lib_dir\/$2/g;
+        if (/(distributionUrl=).*\/(gradle-2.*)/) {
+            s/(distributionUrl=).*\/(gradle-.*)/$1file\\:$lib_dir\/gradle-2.2.1-all.zip/g;
+        } else {
+            s/(distributionUrl=).*\/(gradle-.*)/$1file\\:$lib_dir\/gradle-1.12-bin.zip/g;
+        }
         push(@tmp, $_);
     }
     close(PROP);

--- a/framework/core/Project/Mockito.pm
+++ b/framework/core/Project/Mockito.pm
@@ -73,7 +73,7 @@ sub _post_checkout {
 
     # Change Url to Gradle distribution
     my $prop = "$work_dir/gradle/wrapper/gradle-wrapper.properties";
-    my $lib_dir = "$BUILD_SYSTEMS_LIB_DIR/gradle";
+    my $lib_dir = "$BUILD_SYSTEMS_LIB_DIR/gradle/dists";
 
     # Read existing Gradle properties file, if it exists
     open(PROP, "<$prop") or return;

--- a/framework/core/Project/Mockito.pm
+++ b/framework/core/Project/Mockito.pm
@@ -73,7 +73,7 @@ sub _post_checkout {
 
     # Change Url to Gradle distribution
     my $prop = "$work_dir/gradle/wrapper/gradle-wrapper.properties";
-    my $lib_dir = "$LIB_DIR/build_systems/gradle";
+    my $lib_dir = "$BUILD_SYSTEMS_LIB_DIR/gradle";
 
     # Read existing Gradle properties file, if it exists
     open(PROP, "<$prop") or return;
@@ -99,7 +99,7 @@ sub _post_checkout {
     }
 
     # Enable local repository
-    system("find $work_dir -type f -name \"build.gradle\" -exec sed -i.bak 's|jcenter()|maven { url \"$SCRIPT_DIR/lib/build_systems/gradle/deps\" }\\n jcenter()\\n|g' {} \\;");
+    system("find $work_dir -type f -name \"build.gradle\" -exec sed -i.bak 's|jcenter()|maven { url \"$BUILD_SYSTEMS_LIB_DIR/gradle/deps\" }\\n jcenter()\\n|g' {} \\;");
 }
 
 #

--- a/framework/core/Project/Mockito.pm
+++ b/framework/core/Project/Mockito.pm
@@ -97,6 +97,9 @@ sub _post_checkout {
     if (-e "$work_dir/gradle.properties") {
         system("sed -i.bak s/org.gradle.daemon=true/org.gradle.daemon=false/g \"$work_dir/gradle.properties\"");
     }
+
+    # Enable local repository
+    system("find $work_dir -type f -name \"build.gradle\" -exec sed -i.bak 's|jcenter()|maven { url \"$SCRIPT_DIR/lib/build_systems/gradle/deps\" }\\n jcenter()\\n|g' {} \\;");
 }
 
 #
@@ -183,7 +186,7 @@ sub _ant_call {
     #
     # TODO: Extract all exported environment variables into a user-visible
     # config file.
-    $ENV{'GRADLE_USER_HOME'} = "$self->{prog_root}/.gradle_local_home";
+    $ENV{'GRADLE_USER_HOME'} = "$self->{prog_root}/$GRADLE_LOCAL_HOME_DIR";
     return $self->SUPER::_ant_call($target, $option_str, $log_file);
 }
 

--- a/framework/util/get_gradle_dependencies.pl
+++ b/framework/util/get_gradle_dependencies.pl
@@ -104,7 +104,7 @@ if (system("mkdir -p $TMP_DIR") != 0) {
 }
 
 my $GRADLE_DEPS_DIR = "$TMP_DIR/deps";
-my $GRADLE_DEPS_ZIP = "$SCRIPT_DIR/lib/build_systems/gradle/defects4j-gradle-deps.zip";
+my $GRADLE_DEPS_ZIP = "$BUILD_SYSTEMS_LIB_DIR/gradle/defects4j-gradle-deps.zip";
 if (-e "$GRADLE_DEPS_ZIP") {
     # Unzip existing cache so that can be updated with new dependencies
     if (system("unzip -q -u $GRADLE_DEPS_ZIP -d $TMP_DIR") != 0) {

--- a/framework/util/get_gradle_dependencies.pl
+++ b/framework/util/get_gradle_dependencies.pl
@@ -87,6 +87,11 @@ my @l_time = localtime(time);
 my $month = 1 + $l_time[4]; # the month, i.e., [4] is in the range 0..11 , with 0 indicating January and 11 indicating December
 my $year = 1900 + $l_time[5]; # $year, i.e., [5] contains the number of years since 1900
 
+my $GRADLE_BUILD_SYSTEMS_LIB_DIR = "$BUILD_SYSTEMS_LIB_DIR/gradle";
+if (system("mkdir -p $GRADLE_BUILD_SYSTEMS_LIB_DIR") != 0) {
+    die "Could not create $GRADLE_BUILD_SYSTEMS_LIB_DIR";
+}
+
 #
 # Collect all gradle distributions required to compile all bugs of a particular
 # project
@@ -94,7 +99,7 @@ my $year = 1900 + $l_time[5]; # $year, i.e., [5] contains the number of years si
 
 my $GRADLE_DISTS_DIR = "$TMP_DIR/dists";
 my $GRADLE_DISTS_README = "$GRADLE_DISTS_DIR/README.md";
-my $GRADLE_DISTS_ZIP = "$BUILD_SYSTEMS_LIB_DIR/gradle/defects4j-gradle-dists.zip";
+my $GRADLE_DISTS_ZIP = "$GRADLE_BUILD_SYSTEMS_LIB_DIR/defects4j-gradle-dists.zip";
 
 if (-e "$GRADLE_DISTS_ZIP") {
     # Unzip existing zip so that can be updated with new distributions
@@ -159,13 +164,22 @@ system("rm -rf $TMP_DIR");
 # project
 #
 
+# Make sure that all required gradle distribution versions are available to
+# compile each project version
+if (! -e "$GRADLE_DISTS_ZIP") {
+    die "Could not find '$GRADLE_DISTS_ZIP' therefore no gradle distribution is available";
+}
+if (system("unzip -q -u $GRADLE_DISTS_ZIP -d $GRADLE_BUILD_SYSTEMS_LIB_DIR") != 0) {
+    die "Could not unzip $GRADLE_DISTS_ZIP to $GRADLE_BUILD_SYSTEMS_LIB_DIR";
+}
+
 if (system("mkdir -p $TMP_DIR") != 0) {
     die "Could not create $TMP_DIR directory";
 }
 
 my $GRADLE_DEPS_DIR = "$TMP_DIR/deps";
 my $GRADLE_DEPS_README = "$GRADLE_DEPS_DIR/README.md";
-my $GRADLE_DEPS_ZIP = "$BUILD_SYSTEMS_LIB_DIR/gradle/defects4j-gradle-deps.zip";
+my $GRADLE_DEPS_ZIP = "$GRADLE_BUILD_SYSTEMS_LIB_DIR/defects4j-gradle-deps.zip";
 
 if (-e "$GRADLE_DEPS_ZIP") {
     # Unzip existing cache so that can be updated with new dependencies
@@ -234,3 +248,12 @@ if (system("cd $TMP_DIR && zip -q -r $GRADLE_DEPS_ZIP deps") != 0) {
 
 # Clean up
 system("rm -rf $TMP_DIR");
+
+# Make sure that all (new) gradle dependencies will be available to allow the
+# user to compile any project version that is gradle-based
+if (! -e "$GRADLE_DEPS_ZIP") {
+    die "Could not find '$GRADLE_DEPS_ZIP' therefore no gradle distribution is available";
+}
+if (system("unzip -q -u $GRADLE_DEPS_ZIP -d $GRADLE_BUILD_SYSTEMS_LIB_DIR") != 0) {
+    die "Could not unzip $GRADLE_DEPS_ZIP to $GRADLE_BUILD_SYSTEMS_LIB_DIR";
+}

--- a/framework/util/get_gradle_dependencies.pl
+++ b/framework/util/get_gradle_dependencies.pl
@@ -242,7 +242,7 @@ foreach my $bid (@ids) {
 system("cd $GRADLE_DEPS_DIR && find * -type f ! -name 'README.md' -exec echo {} >> $GRADLE_DEPS_README \\;");
 
 # Zip gradle dependencies
-if (system("cd $TMP_DIR && zip -q -r $GRADLE_DEPS_ZIP deps") != 0) {
+if (system("cd $TMP_DIR && find deps -type d -empty -delete && zip -q -r $GRADLE_DEPS_ZIP deps") != 0) {
     die "Could not zip $TMP_DIR/deps";
 }
 

--- a/framework/util/get_gradle_dependencies.pl
+++ b/framework/util/get_gradle_dependencies.pl
@@ -27,7 +27,7 @@
 =head1 NAME
 
 get_gradle_dependencies.pl -- obtain a list of all gradle versions used in the
-entire history of a particular project.
+entire history of a particular project and collect all gradle dependencies.
 
 =head1 SYNOPSIS
 
@@ -36,7 +36,7 @@ entire history of a particular project.
 =head1 DESCRIPTION
 
 Extract all references to gradle distributions from the project's version
-control history.
+control history and collect all dependencies.
 
 B<TODO: This script currently expects the repository to be a git repository!>
 
@@ -46,7 +46,8 @@ B<TODO: This script currently expects the repository to be a git repository!>
 
 =item -p C<project_id>
 
-The id of the project for which the list of gradle dependencies is extracted.
+The id of the project for which the list of gradle versions and dependencies are
+extracted.
 
 =back
 
@@ -89,8 +90,90 @@ foreach (split(/\n/, $log)) {
     /[+-]distributionUrl=(.+)/ or die "Unexpected line extracted: $_!";
     my $url = $1;
     $url =~ s/\\:/:/g;
-    $all_deps{$url} = 1;   
+    $all_deps{$url} = 1;
 }
 
 # Print the ordered list of dependencies to STDOUT
 print(join("\n", sort(keys(%all_deps))), "\n");
+
+# Collect all dependencies of a particular project
+
+my $TMP_DIR = Utils::get_tmp_dir();
+if (system("mkdir -p $TMP_DIR") != 0) {
+    die "Could not create $TMP_DIR directory";
+}
+
+my $GRADLE_DEPS_DIR = "$TMP_DIR/deps";
+my $GRADLE_DEPS_ZIP = "$SCRIPT_DIR/lib/build_systems/gradle/defects4j-gradle-deps.zip";
+if (-e "$GRADLE_DEPS_ZIP") {
+    # Unzip existing cache so that can be updated with new dependencies
+    if (system("unzip -q -u $GRADLE_DEPS_ZIP -d $TMP_DIR") != 0) {
+        die "Could not unzip $GRADLE_DEPS_ZIP";
+    }
+} else {
+    if (system("mkdir -p $GRADLE_DEPS_DIR") != 0) {
+        die "Could not create $GRADLE_DEPS_DIR directory";
+    }
+}
+
+my @ids = $project->get_version_ids();
+foreach my $bid (@ids) {
+    # Checkout a project version
+    my $vid = "${bid}f";
+    $project->{prog_root} = "$TMP_DIR/$PID-$vid";
+    $project->checkout_vid($vid) or die "Could not checkout $PID-${vid}";
+
+    # Compile the project using the gradle wrapper, if it exits (this step
+    # should force the download of all dependencies to a local gradle directory)
+#    if (! -e "$project->{prog_root}/gradlew") {
+#        next;
+#    }
+#    my $log = "";
+#    my $cmd = "export GRADLE_USER_HOME=$project->{prog_root}/$GRADLE_LOCAL_HOME_DIR && \
+#               cd $project->{prog_root} && \
+#               ./gradlew -xtestClasses -xtest classes && \
+#               ./gradlew -xtest testClasses && \
+#               ./gradlew --stop";
+#    Utils::exec_cmd($cmd, "Compiling the project with gradle", \$log);
+    $project->compile() or die "Could not compile source code";
+    $project->compile_tests() or die "Could not compile test suites";
+
+    my $gradle_caches_dir = "$project->{prog_root}/$GRADLE_LOCAL_HOME_DIR/caches/modules-2/files-2.1";
+    if (! -d $gradle_caches_dir) {
+        next;
+    }
+
+    # Collect all dependencies
+
+    # Convert pom and jar files from, e.g.,
+    # $gradle_caches_dir/org.ow2.asm/asm/5.0.4/b4b92f4b84715dec57de734ff4c3098aa6904d06/asm-5.0.4.pom
+    # $gradle_caches_dir/org.ow2.asm/asm/5.0.4/da08b8cce7bbf903602a25a3a163ae252435795/asm-5.0.4.jar
+    # to
+    # $GRADLE_DEPS_DIR/org/ow2/asm/asm/5.0.4/asm-5.0.4.pom
+    # $GRADLE_DEPS_DIR/org/ow2/asm/asm/5.0.4/asm-5.0.4.jar
+    $log = "";
+    $cmd = "cd $gradle_caches_dir && \
+            find . -type f | while read -r f; do \
+                d=\$(dirname \$f) \
+                mv \"\$f\" \"\$d/../\" \
+            done \
+            for d in \$(find . -mindepth 1 -maxdepth 1 -type d -printf '%f\\n'); do \
+                artifact_dir=$GRADLE_DEPS_DIR/\$(echo \$d | tr '.' '/') \
+                mkdir -p \$artifact_dir && \
+                (cd \$d && cp -u -R . \$artifact_dir) \
+            done";
+    Utils::exec_cmd($cmd, "Collecting all project dependencies", \$log);
+
+    # Remove checkout dir
+    if (system("rm -rf $project->{prog_root}") != 0) {
+        die "Could not remove $project->{prog_root}";
+    }
+}
+
+# Zip gradle dependencies
+if (system("cd $TMP_DIR && zip -q -r $GRADLE_DEPS_ZIP deps") != 0) {
+    die "Could not zip $TMP_DIR/deps";
+}
+
+# Clean up
+system("rm -rf $TMP_DIR");

--- a/framework/util/get_gradle_dependencies.pl
+++ b/framework/util/get_gradle_dependencies.pl
@@ -130,18 +130,8 @@ foreach my $bid (@ids) {
     $project->{prog_root} = "$TMP_DIR/$PID-$vid";
     $project->checkout_vid($vid) or die "Could not checkout $PID-${vid}";
 
-    # Compile the project using the gradle wrapper, if it exits (this step
-    # should force the download of all dependencies to a local gradle directory)
-#    if (! -e "$project->{prog_root}/gradlew") {
-#        next;
-#    }
-#    my $log = "";
-#    my $cmd = "export GRADLE_USER_HOME=$project->{prog_root}/$GRADLE_LOCAL_HOME_DIR && \
-#               cd $project->{prog_root} && \
-#               ./gradlew -xtestClasses -xtest classes && \
-#               ./gradlew -xtest testClasses && \
-#               ./gradlew --stop";
-#    Utils::exec_cmd($cmd, "Compiling the project with gradle", \$log);
+    # Compile the project using the D4J API (this step should force the download
+    # of all dependencies to a local gradle directory)
     $project->compile() or die "Could not compile source code";
     $project->compile_tests() or die "Could not compile test suites";
 

--- a/framework/util/get_gradle_dependencies.pl
+++ b/framework/util/get_gradle_dependencies.pl
@@ -104,7 +104,9 @@ if (system("mkdir -p $TMP_DIR") != 0) {
 }
 
 my $GRADLE_DEPS_DIR = "$TMP_DIR/deps";
+my $GRADLE_DEPS_README = "$TMP_DIR/deps/README.md";
 my $GRADLE_DEPS_ZIP = "$BUILD_SYSTEMS_LIB_DIR/gradle/defects4j-gradle-deps.zip";
+
 if (-e "$GRADLE_DEPS_ZIP") {
     # Unzip existing cache so that can be updated with new dependencies
     if (system("unzip -q -u $GRADLE_DEPS_ZIP -d $TMP_DIR") != 0) {
@@ -115,6 +117,11 @@ if (-e "$GRADLE_DEPS_ZIP") {
         die "Could not create $GRADLE_DEPS_DIR directory";
     }
 }
+
+my @l_time = localtime(time);
+my $month = 1 + $l_time[4]; # the month, i.e., [4] is in the range 0..11 , with 0 indicating January and 11 indicating December
+my $year = 1900 + $l_time[5]; # $year, i.e., [5] contains the number of years since 1900
+system("echo \"Gradle dependencies updated: ${month}/${year}\\n\" > $GRADLE_DEPS_README");
 
 my @ids = $project->get_version_ids();
 foreach my $bid (@ids) {
@@ -169,6 +176,9 @@ foreach my $bid (@ids) {
         die "Could not remove $project->{prog_root}";
     }
 }
+
+# Updated README file with all dependencies
+system("cd $GRADLE_DEPS_DIR && find * -type f ! -name 'README.md' -exec echo {} >> $GRADLE_DEPS_README \\;");
 
 # Zip gradle dependencies
 if (system("cd $TMP_DIR && zip -q -r $GRADLE_DEPS_ZIP deps") != 0) {

--- a/init.sh
+++ b/init.sh
@@ -142,7 +142,7 @@ new_dists_ts=$($dists_ts)
 new_deps_ts=$($deps_ts)
 
 # Update gradle distributions/dependencies if a newer archive was available
-[ "$old_dists_ts" != "$new_dists_ts" ] && unzip -q -u $GRADLE_DISTS_ZIP
+[ "$old_dists_ts" != "$new_dists_ts" ] && mkdir "dists" && unzip -q -u $GRADLE_DISTS_ZIP -d "dists"
 [ "$old_deps_ts" != "$new_deps_ts" ] && unzip -q -u $GRADLE_DEPS_ZIP
 
 cd "$BASE"

--- a/init.sh
+++ b/init.sh
@@ -29,8 +29,8 @@ mkdir -p "$DIR_LIB_GEN" && mkdir -p "$DIR_LIB_RT" && mkdir -p "$DIR_LIB_GRADLE"
 #
 
 # Get time of last data modification of a file
-get_time_of_last_data_modification() {
-    local USAGE="Usage: get_status <file>"
+get_modification_timestamp() {
+    local USAGE="Usage: get_modification_timestamp <file>"
     if [ "$#" != 1 ]; then
         echo "$USAGE" >&2
         exit 1
@@ -47,7 +47,8 @@ get_time_of_last_data_modification() {
         cmd="stat -f %m $f"
     fi
 
-    echo "$cmd"
+    local ts=$($cmd)
+    echo "$ts"
 }
 
 ################################################################################
@@ -118,8 +119,8 @@ echo "Setting up Gradle dependencies ... "
 GRADLE_DISTS_ZIP=defects4j-gradle-dists.zip
 GRADLE_DEPS_ZIP=defects4j-gradle-deps.zip
 
-dists_ts_cmd=$(get_time_of_last_data_modification $GRADLE_DISTS_ZIP)
-deps_ts_cmd=$(get_time_of_last_data_modification $GRADLE_DEPS_ZIP)
+dists_ts=$(get_modification_timestamp $GRADLE_DISTS_ZIP)
+deps_ts=$(get_modification_timestamp $GRADLE_DEPS_ZIP)
 
 cd "$DIR_LIB_GRADLE"
 
@@ -127,17 +128,17 @@ old_dists_ts=0
 old_deps_ts=0
 
 if [ -e $GRADLE_DISTS_ZIP ]; then
-    old_dists_ts=$($dists_ts_cmd)
+    old_dists_ts=$($dists_ts)
 fi
 if [ -e $GRADLE_DEPS_ZIP ]; then
-    old_deps_ts=$($deps_ts_cmd)
+    old_deps_ts=$($deps_ts)
 fi
 
 # Only download archive if the server has a newer file
 wget -N http://people.cs.umass.edu/~rjust/defects4j/download/$GRADLE_DISTS_ZIP
 wget -N http://people.cs.umass.edu/~rjust/defects4j/download/$GRADLE_DEPS_ZIP
-new_dists_ts=$($dists_ts_cmd)
-new_deps_ts=$($deps_ts_cmd)
+new_dists_ts=$($dists_ts)
+new_deps_ts=$($deps_ts)
 
 # Update gradle distributions/dependencies if a newer archive was available
 [ "$old_dists_ts" != "$new_dists_ts" ] && unzip -q -u $GRADLE_DISTS_ZIP

--- a/init.sh
+++ b/init.sh
@@ -117,29 +117,26 @@ cd "$DIR_LIB_GEN" && [ ! -f "$REPLACECALL_JAR" ] \
 echo
 echo "Setting up Gradle dependencies ... "
 
+cd "$DIR_LIB_GRADLE"
+
 GRADLE_DISTS_ZIP=defects4j-gradle-dists.zip
 GRADLE_DEPS_ZIP=defects4j-gradle-deps.zip
-
-dists_ts=$(get_modification_timestamp $GRADLE_DISTS_ZIP)
-deps_ts=$(get_modification_timestamp $GRADLE_DEPS_ZIP)
-
-cd "$DIR_LIB_GRADLE"
 
 old_dists_ts=0
 old_deps_ts=0
 
 if [ -e $GRADLE_DISTS_ZIP ]; then
-    old_dists_ts=$($dists_ts)
+    old_dists_ts=$(get_modification_timestamp $GRADLE_DISTS_ZIP)
 fi
 if [ -e $GRADLE_DEPS_ZIP ]; then
-    old_deps_ts=$($deps_ts)
+    old_deps_ts=$(get_modification_timestamp $GRADLE_DEPS_ZIP)
 fi
 
 # Only download archive if the server has a newer file
 wget -N $HOST_URL/$GRADLE_DISTS_ZIP
 wget -N $HOST_URL/$GRADLE_DEPS_ZIP
-new_dists_ts=$($dists_ts)
-new_deps_ts=$($deps_ts)
+new_dists_ts=$(get_modification_timestamp $GRADLE_DISTS_ZIP)
+new_deps_ts=$(get_modification_timestamp $GRADLE_DEPS_ZIP)
 
 # Update gradle distributions/dependencies if a newer archive was available
 [ "$old_dists_ts" != "$new_dists_ts" ] && mkdir "dists" && unzip -q -u $GRADLE_DISTS_ZIP -d "dists"

--- a/init.sh
+++ b/init.sh
@@ -15,6 +15,8 @@ if ! wget --version > /dev/null 2>&1; then
     exit 1
 fi
 
+HOST_URL="http://people.cs.umass.edu/~rjust/defects4j/download"
+
 # Directories for project repositories and external libraries
 BASE="$(cd $(dirname $0); pwd)"
 DIR_REPOS="$BASE/project_repos"
@@ -79,13 +81,12 @@ cd "$BASE" && wget -nv -N "$MAJOR_URL/$MAJOR_ZIP" \
 echo
 echo "Setting up EvoSuite ... "
 EVOSUITE_VERSION="0.2.0"
-EVOSUITE_URL="http://people.cs.umass.edu/~rjust/defects4j/download"
 EVOSUITE_JAR="evosuite-${EVOSUITE_VERSION}.jar"
 EVOSUITE_RT_JAR="evosuite-standalone-runtime-${EVOSUITE_VERSION}.jar"
 cd "$DIR_LIB_GEN" && [ ! -f "$EVOSUITE_JAR" ] \
-                  && wget -nv "$EVOSUITE_URL/$EVOSUITE_JAR"
+                  && wget -nv "$HOST_URL/$EVOSUITE_JAR"
 cd "$DIR_LIB_RT"  && [ ! -f "$EVOSUITE_RT_JAR" ] \
-                  && wget -nv "$EVOSUITE_URL/$EVOSUITE_RT_JAR"
+                  && wget -nv "$HOST_URL/$EVOSUITE_RT_JAR"
 # Set symlinks for the supported version of EvoSuite
 (cd "$DIR_LIB_GEN" && ln -sf "$EVOSUITE_JAR" "evosuite-current.jar")
 (cd "$DIR_LIB_RT" && ln -sf "$EVOSUITE_RT_JAR" "evosuite-rt.jar")
@@ -135,8 +136,8 @@ if [ -e $GRADLE_DEPS_ZIP ]; then
 fi
 
 # Only download archive if the server has a newer file
-wget -N http://people.cs.umass.edu/~rjust/defects4j/download/$GRADLE_DISTS_ZIP
-wget -N http://people.cs.umass.edu/~rjust/defects4j/download/$GRADLE_DEPS_ZIP
+wget -N $HOST_URL/$GRADLE_DISTS_ZIP
+wget -N $HOST_URL/$GRADLE_DEPS_ZIP
 new_dists_ts=$($dists_ts)
 new_deps_ts=$($deps_ts)
 

--- a/init.sh
+++ b/init.sh
@@ -33,7 +33,7 @@ get_time_of_last_data_modification() {
     local USAGE="Usage: get_status <file>"
     if [ "$#" != 1 ]; then
         echo "$USAGE" >&2
-        return 1
+        exit 1
     fi
 
     local f="$1"
@@ -48,7 +48,6 @@ get_time_of_last_data_modification() {
     fi
 
     echo "$cmd"
-    return 0
 }
 
 ################################################################################


### PR DESCRIPTION
- Updated 'get_gradle_dependencies.pl' to create a super set of all required dependencies.
- Updated init script to download/extract all Gradle dependencies.
- Make Mockito gradle-based bugs use the super set of dependencies.