### PR TITLE
Clarifies README for Setting Up Randoop

### DIFF
--- a/framework/test/README.md
+++ b/framework/test/README.md
@@ -35,7 +35,11 @@ defects (see the top-level
 [README](https://github.com/rjust/defects4j/blob/master/README.md) for
 more details about the defects and requirements).
 
-1. Optionally, indicate where to find the version of Randoop you wish to test.
+1. Follow steps 1-4 under 
+[Steps to set up Defects4J](https://github.com/rjust/defects4j/blob/master/README.md#steps-to-set-up-defects4j)
+ in the top-level README.
+
+2. Optionally, indicate where to find the version of Randoop you wish to test.
     - `export TESTGEN_LIB_DIR="path2directory-containing-randoop-current.jar"`
 
     The randoop.jar you wish to test must be named randoop-current.jar.
@@ -45,7 +49,7 @@ more details about the defects and requirements).
     matching version of replacecall.jar to replacecall-current.jar in the same location as
     randoop-current.jar.
 
-2. Run the test generation and coverage analysis:
+3. Run the test generation and coverage analysis:
     - `./randoop_coverage.sh`
 
     Currently, this does not generate tests for all the defects, just five in
@@ -56,7 +60,7 @@ more details about the defects and requirements).
     The test scripts set `TMP_DIR` to */tmp/test_d4j*. If you wish to change
     this, you will need to modify `./test.include`.
 
-3. Display the coverage data:
+4. Display the coverage data:
     - `../util/show_coverage.pl`
 
     The raw coverage data is found at *$TMP_DIR/test_d4j/coverage*.


### PR DESCRIPTION
Makes it explicit to set up Defects4J first.