### PR TITLE
README - Fixing broken link to framework/test

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Using Defects4J
     - `defects4j compile`
     - `defects4j test`
 
-5. The scripts in [`framework/test/`](tree/master/framework/test/)
+5. The scripts in [`framework/test/`](framework/test/)
 are examples of how to use Defects4J, which you might find useful
 as inspiration when you are writing your own scripts that use Defects4J.
 


### PR DESCRIPTION
GitHub markdown is creating a broken link.
The change should fix it.