### PR TITLE
add omitted mockito.git in clean function

### DIFF
--- a/project_repos/get_repos.sh
+++ b/project_repos/get_repos.sh
@@ -12,6 +12,7 @@ clean() {
     commons-math.git \
     jfreechart \
     joda-time.git \
+    mockito.git \
     README 
 }
 


### PR DESCRIPTION
A very small change. Without cleaning mockito.git, the get_repos.sh may report error like "mv: cannot move ‘defects4j/project_repos/mockito.git’ to ‘./mockito.git’: Directory not empty" during execution.