### PR TITLE
Delete old test results prior to running tests or computing coverage.

### DIFF
--- a/framework/bin/d4j/d4j-coverage
+++ b/framework/bin/d4j/d4j-coverage
@@ -129,8 +129,11 @@ my $src_dir = $project->src_dir($vid);
 # Classes to instrument for coverage analysis -- default is all modified classes
 my $classes = $INSTRUMENT // "$SCRIPT_DIR/projects/$pid/modified_classes/$bid.src";
 
-my $test_log = "$WORK_DIR/failing_tests";
-system(">$test_log");
+# Clean temporary files that hold test results
+my $fail_tests = "$WORK_DIR/failing_tests";
+my $all_tests = "$WORK_DIR/all_tests";
+system(">$fail_tests");
+system(">$all_tests");
 
 # Run the test suite, according to the provided flags
 my $cov_results;
@@ -139,15 +142,15 @@ if (defined $TEST_SUITE) {
     my $test_dir = "$WORK_DIR/.test_suite";
     Utils::extract_test_suite($TEST_SUITE, $test_dir) or die;
     $project->compile_ext_tests($test_dir) or die "Cannot compile extracted test suite!";
-    $cov_results = Coverage::coverage_ext($project, $classes, $src_dir, $test_dir, "*.java", $test_log, $SINGLE_TEST);
+    $cov_results = Coverage::coverage_ext($project, $classes, $src_dir, $test_dir, "*.java", $fail_tests, $SINGLE_TEST);
 } elsif ($REL_TESTS) {
     # Compile and run only relevant developer-written tests
     $project->compile_tests() or die "Cannot compile test suite!";
-    $cov_results = Coverage::coverage($project, $classes, $src_dir, $test_log, $REL_TESTS);
+    $cov_results = Coverage::coverage($project, $classes, $src_dir, $fail_tests, $REL_TESTS);
 } else {
     # Compile and run developer-written tests
     $project->compile_tests() or die "Cannot compile test suite!";
-    $cov_results = Coverage::coverage($project, $classes, $src_dir, $test_log, undef, $SINGLE_TEST);
+    $cov_results = Coverage::coverage($project, $classes, $src_dir, $fail_tests, undef, $SINGLE_TEST);
 }
 defined $cov_results or die "Couldn't obtain coverage results!";
 
@@ -169,7 +172,7 @@ printf("%18s: %.1f%%\n", "Condition coverage", ($cov_results->{branches_total} =
 #printf("%17s: %.1f seconds\n", "Total run time", ($timeAnalysis));
 
 # Issue a warning if any test failed as this might give misleading results
-Utils::has_failing_tests($test_log)
-        and print(STDERR "WARNING: Some tests failed (see $test_log)!\n");
+Utils::has_failing_tests($fail_tests)
+        and print(STDERR "WARNING: Some tests failed (see $fail_tests)!\n");
 
 1;

--- a/framework/bin/d4j/d4j-coverage
+++ b/framework/bin/d4j/d4j-coverage
@@ -130,10 +130,8 @@ my $src_dir = $project->src_dir($vid);
 my $classes = $INSTRUMENT // "$SCRIPT_DIR/projects/$pid/modified_classes/$bid.src";
 
 # Clean temporary files that hold test results
-my $fail_tests = "$WORK_DIR/failing_tests";
-my $all_tests = "$WORK_DIR/all_tests";
-system(">$fail_tests");
-system(">$all_tests");
+my $fail_tests = "$WORK_DIR/$FILE_FAILING_TESTS";
+Utils::clean_test_results($WORK_DIR);
 
 # Run the test suite, according to the provided flags
 my $cov_results;

--- a/framework/bin/d4j/d4j-test
+++ b/framework/bin/d4j/d4j-test
@@ -115,10 +115,8 @@ my $project = Project::create_project($config->{$CONFIG_PID});
 $project->{prog_root} = $WORK_DIR;
 
 # Clean temporary files that hold test results
-my $fail_tests = "$WORK_DIR/failing_tests";
-my $all_tests = "$WORK_DIR/all_tests";
-system(">$fail_tests");
-system(">$all_tests");
+my $fail_tests = "$WORK_DIR/$FILE_FAILING_TESTS";
+Utils::clean_test_results($WORK_DIR);
 
 # Run the test suite, according to the provided flags
 if (defined $TEST_SUITE){

--- a/framework/bin/d4j/d4j-test
+++ b/framework/bin/d4j/d4j-test
@@ -114,9 +114,11 @@ unless(defined $config) {
 my $project = Project::create_project($config->{$CONFIG_PID});
 $project->{prog_root} = $WORK_DIR;
 
-# Clean temporary file that holds test results
-my $tmp = "$WORK_DIR/failing_tests";
-`>$tmp`;
+# Clean temporary files that hold test results
+my $fail_tests = "$WORK_DIR/failing_tests";
+my $all_tests = "$WORK_DIR/all_tests";
+system(">$fail_tests");
+system(">$all_tests");
 
 # Run the test suite, according to the provided flags
 if (defined $TEST_SUITE){
@@ -124,18 +126,18 @@ if (defined $TEST_SUITE){
     my $test_dir = "$WORK_DIR/.test_suite";
     Utils::extract_test_suite($TEST_SUITE, $test_dir) or die;
     $project->compile_ext_tests($test_dir) or die "Cannot compile extracted test suite!";
-    $project->run_ext_tests($test_dir, "*.java", $tmp, $SINGLE_TEST) or die "Cannot run tests!";
+    $project->run_ext_tests($test_dir, "*.java", $fail_tests, $SINGLE_TEST) or die "Cannot run tests!";
 } elsif ($REL_TESTS) {
     # Compile and run only relevant developer-written tests
     $project->compile_tests() or die "Cannot compile test suite!";
-    $project->run_relevant_tests($tmp) or die "Cannot run tests!";
+    $project->run_relevant_tests($fail_tests) or die "Cannot run tests!";
 } else {
     # Compile and run developer-written tests
     $project->compile_tests() or die "Cannot compile test suite!";
-    $project->run_tests($tmp, $SINGLE_TEST) or die "Cannot run tests!";
+    $project->run_tests($fail_tests, $SINGLE_TEST) or die "Cannot run tests!";
 }
 
-my $trigger = Utils::get_failing_tests($tmp) or die "Cannot determine triggering tests!";
+my $trigger = Utils::get_failing_tests($fail_tests) or die "Cannot determine triggering tests!";
 my $count = scalar(@{$trigger->{methods}}) + scalar(@{$trigger->{classes}});
 
 print "Failing tests: $count\n";

--- a/framework/core/Constants.pm
+++ b/framework/core/Constants.pm
@@ -235,7 +235,8 @@ our $CONFIG_PID = "pid";
 our $CONFIG_VID = "vid";
 
 # Filename which stores build properties
-our $PROP_FILE       = "defects4j.build.properties";
+our $PROP_FILE = "defects4j.build.properties";
+
 # Keys of stored properties
 our $PROP_EXCLUDE         = "d4j.tests.exclude";
 our $PROP_INSTRUMENT      = "d4j.classes.instrument";
@@ -248,11 +249,16 @@ our $PROP_TESTS_TRIGGER   = "d4j.tests.trigger";
 our $PROP_PID             = "d4j.project.id";
 our $PROP_BID             = "d4j.bug.id";
 
+# Tags for local git repo in working directory
 our $TAG_POST_FIX         = "POST_FIX_REVISION";
 our $TAG_POST_FIX_COMP    = "POST_FIX_COMPILABLE";
 our $TAG_FIXED            = "FIXED_VERSION";
 our $TAG_BUGGY            = "BUGGY_VERSION";
 our $TAG_PRE_FIX          = "PRE_FIX_REVISION";
+
+# Filenames for test results
+our $FILE_ALL_TESTS     = "all_tests";
+our $FILE_FAILING_TESTS = "failing_tests";
 
 our @EXPORT = qw(
 $SCRIPT_DIR
@@ -296,6 +302,9 @@ $TAG_POST_FIX_COMP
 $TAG_FIXED
 $TAG_BUGGY
 $TAG_PRE_FIX
+
+$FILE_ALL_TESTS
+$FILE_FAILING_TESTS
 
 $DEBUG
 );

--- a/framework/core/Utils.pm
+++ b/framework/core/Utils.pm
@@ -413,7 +413,7 @@ sub append_to_file_unless_matches {
 
 =item B<files_in_commit> C<files_in_commit(repo_dir,commit)>
 
-This utility method takes C<commit> and get the files it changes
+Returns an array of files changed in C<commit>.
 
 =cut
 sub files_in_commit {
@@ -451,6 +451,28 @@ sub bug_report_info {
     close IN;
 
     return $bug_report_info;
+}
+
+=pod
+
+=item B<clean_test_results> C<clean_test_results(work_dir)>
+
+Remove any old test results in the provided C<work_dir>.
+
+=cut
+sub clean_test_results {
+    my ($work_dir) = @_;
+
+    # Remove the files that list all tests and failing tests
+    my $fail_tests = "$work_dir/$FILE_FAILING_TESTS";
+    my $all_tests = "$work_dir/$FILE_ALL_TESTS";
+
+    if (-e "$fail_tests") {
+        unlink("$fail_tests") == 1 or die("Cannot delete 'failing_tests': $!")
+    }
+    if (-e "$all_tests") {
+        unlink("$all_tests") == 1 or die("Cannot delete 'all_tests': $!")
+    }
 }
 
 1;


### PR DESCRIPTION
Some additional clean up (variable naming and making the file name for all_tests a parameter) would be great, but should go into a separate PR.