### PR TITLE
Fix mutation analysis of generated tests for Mockito (addresses issue #308)

### DIFF
--- a/framework/core/Constants.pm
+++ b/framework/core/Constants.pm
@@ -48,7 +48,7 @@ our @ISA = qw(Exporter);
 my $dir = dirname(abs_path(__FILE__));
 
 # Enable debugging and verbose output
-our $DEBUG = 0;
+our $DEBUG = $ENV{'D4J_DEBUG'} // 0;
 
 =pod
 
@@ -232,8 +232,6 @@ unshift(@INC, $SCRIPT_DIR);
 unshift(@INC, $LIB_DIR);
 # Append Major's executables to the PATH -> ant may not be installed by default
 $ENV{PATH}="$ENV{PATH}:$MAJOR_ROOT/bin";
-# set name of mml file that provides definitions of used mutation operators
-$ENV{MML}="$MAJOR_ROOT/mml/all_mutants.mml.bin" unless defined $ENV{'MML'};
 
 # Constant strings used for errors
 our $ARG_ERROR       = "Invalid number of arguments!";

--- a/framework/core/Project.pm
+++ b/framework/core/Project.pm
@@ -767,7 +767,11 @@ sub mutate {
     $ENV{MML} = $mml_bin;
 
     # Mutate and compile sources
-    if (! $self->_call_major("mutate")) {
+    my $ret = $self->_call_major("mutate");
+
+    delete($ENV{MML});
+
+    if (! $ret) {
         return -1;
     }
 
@@ -1031,9 +1035,14 @@ sub _call_major {
     @_ >= 2 or die $ARG_ERROR;
     my ($self, $target, $option_str, $log_file, $ant_cmd) =  @_;
     $option_str = "-Dbuild.compiler=major.ant.MajorCompiler " . ($option_str // "");
+    # Prepend path with Major's executables
+    my $path = $ENV{PATH};
     $ENV{PATH}="$MAJOR_ROOT/bin:$ENV{PATH}";
     $ant_cmd = "$MAJOR_ROOT/bin/ant" unless defined $ant_cmd;
-    return $self->_ant_call($target, $option_str, $log_file, $ant_cmd);
+    my $ret = $self->_ant_call($target, $option_str, $log_file, $ant_cmd);
+    # Reset path for downstream calls to ant
+    $ENV{PATH} = $path;
+    return($ret);
 }
 
 #

--- a/framework/projects/defects4j.build.xml
+++ b/framework/projects/defects4j.build.xml
@@ -60,6 +60,8 @@ project-specific build file ("project_id"/"project_id".build.xml) for the
 
     <!-- Location of customized JUnit formatter-->
     <property name="formatter.jar" value="${d4j.home}/framework/lib/formatter.jar"/>
+    <!-- Directory of compiled test-gen classes -->
+    <property name="d4j.dir.classes.testgen" value="${d4j.workdir}/.classes_testgen"/>
     <!-- Directory of instrumented classes (e.g., for coverage analysis)-->
     <property name="d4j.dir.classes.instrumented" value="${d4j.workdir}/.classes_instrumented"/>
     <!-- Directory of mutated classes-->
@@ -143,7 +145,7 @@ project-specific build file ("project_id"/"project_id".build.xml) for the
             <classpath>
                 <pathelement path="${formatter.jar}" />
                 <pathelement path="${junit.jar}" />
-                <pathelement path="${build.home}/gen-tests" />
+                <pathelement path="${d4j.dir.classes.testgen}" />
                 <path refid="d4j.test.classpath"/>
                 <!-- Add dependencies to runtime libraries of test generation tools -->
                 <path refid="d4j.lib.testgen.rt"/>
@@ -184,7 +186,7 @@ project-specific build file ("project_id"/"project_id".build.xml) for the
 <!--
     Run mutation analysis
 -->
-    <target name="mutation.test" depends="compile.tests,update.all.tests" description="Perform mutation analysis">
+    <target name="mutation.test" depends="update.all.tests" description="Perform mutation analysis">
         <!-- Test a generated test suite -->
         <if><isset property="d4j.test.include"/>
             <then>
@@ -229,7 +231,7 @@ project-specific build file ("project_id"/"project_id".build.xml) for the
 
             <classpath>
                 <pathelement location="${d4j.dir.classes.mutated}" />
-                <pathelement path="${build.home}/gen-tests" />
+                <pathelement path="${d4j.dir.classes.testgen}" />
                 <path refid="d4j.test.classpath"/>
                 <!-- Add dependencies to runtime libraries of test generation tools -->
                 <path refid="d4j.lib.testgen.rt"/>
@@ -254,10 +256,10 @@ project-specific build file ("project_id"/"project_id".build.xml) for the
         <echo message="classes.dir: ${classes.dir}" />
         <echo message="build.home: ${build.home}" />
 
-        <delete dir="${build.home}/gen-tests" quiet="true" />
-        <mkdir dir="${build.home}/gen-tests" />
+        <delete dir="${d4j.dir.classes.testgen}" quiet="true" />
+        <mkdir dir="${d4j.dir.classes.testgen}" />
         <javac srcdir="${d4j.test.dir}"
-               destdir="${build.home}/gen-tests"
+               destdir="${d4j.dir.classes.testgen}"
                debug="true"
                deprecation="false"
                optimize="false">
@@ -288,7 +290,7 @@ project-specific build file ("project_id"/"project_id".build.xml) for the
                 <!-- Make sure that instrumented classes appear at the beginning of the
                      classpath -->
                 <pathelement location="${d4j.dir.classes.instrumented}" />
-                <pathelement path="${build.home}/gen-tests" />
+                <pathelement path="${d4j.dir.classes.testgen}" />
                 <pathelement path="${formatter.jar}" />
                 <pathelement path="${junit.jar}" />
                 <pathelement path="${classes.dir}" />


### PR DESCRIPTION
This PR makes three changes:
1. It properly sets and unsets environment variables for mutation.
2. It changes the output directory for the compilation of generated tests (the compiled classes were previously written to the project's target directory, which may however be deleted during init or unrelated compilation tasks.)
3. Debugging in Defects4J can now be enabled by exporting `D4J_DEBUG` from the command line, prior to executing Defects4J commands.