### PR TITLE
Tidy up

### DIFF
--- a/framework/bin/gen_tests.pl
+++ b/framework/bin/gen_tests.pl
@@ -305,7 +305,8 @@ exit($ret_code);
 ################################################################################
 # Check whether the requested generator is valid
 sub is_generator_valid {
-    my $tool = shift;
+    @_ == 1 or die $ARG_ERROR;
+    my ($tool) = @_;
     my %all_tools;
     opendir(my $dir, "$TESTGEN_BIN_DIR") || die("Cannot read test generators: $!");
         while (readdir $dir) {

--- a/framework/bin/run_klocs.pl
+++ b/framework/bin/run_klocs.pl
@@ -109,7 +109,7 @@ $TID =~ /^\d+$/ or die "Wrong test_id format (\\d+): $TID!";
 my $OUT_DIR = $cmd_opts{o};
 
 # Enable debugging if flag is set
-#$DEBUG = 1 if defined $cmd_opts{D};
+$DEBUG = 1 if defined $cmd_opts{D};
 
 if ($DEBUG) {
   Utils::print_env();

--- a/framework/core/DB.pm
+++ b/framework/core/DB.pm
@@ -287,8 +287,9 @@ the database and the requested C<table> if necessary.
 =cut
 
 sub get_db_handle {
-    my $table = shift @_ // die $ARG_ERROR;
-    my $db_dir = shift @_ // $DB_DIR;
+    @_ >= 2 or die $ARG_ERROR;
+    my ($table, $db_dir) = @_;
+    $db_dir //= $DB_DIR;
     my $dbh;
 
     defined $tables{$table} or die "Unknown table: $table!";
@@ -322,6 +323,7 @@ Returns a list of column names for C<table> or C<undef> if this table does not e
 =cut
 
 sub get_tab_columns {
-    my $table = shift;
+    @_ == 1 or die $ARG_ERROR;
+    my ($table) = @_;
     return @{$tables{$table}};
 }

--- a/framework/core/DB.pm
+++ b/framework/core/DB.pm
@@ -287,7 +287,7 @@ the database and the requested C<table> if necessary.
 =cut
 
 sub get_db_handle {
-    @_ >= 2 or die $ARG_ERROR;
+    @_ >= 1 or die $ARG_ERROR;
     my ($table, $db_dir) = @_;
     $db_dir //= $DB_DIR;
     my $dbh;

--- a/framework/core/Log.pm
+++ b/framework/core/Log.pm
@@ -50,6 +50,8 @@ use warnings;
 use strict;
 use POSIX qw(strftime);
 
+use Constants;
+
 =pod
 
 =head2 Create an instance of Log
@@ -61,7 +63,7 @@ Open log file with open mode append (default) and return reference to log object
 =cut
 
 sub create_log {
-    @_ >= 1 or die "Invalid number of arguments";
+    @_ >= 1 or die $ARG_ERROR;
     my ($file_name, $mode) = @_;
     my $open_mode = defined $mode ? $mode : ">>";
     open(my $fh, "$open_mode", "$file_name") or die "Cannot open log file $file_name: $!";
@@ -84,7 +86,7 @@ Log provided message.
 =cut
 
 sub log_msg {
-    @_ == 2 or die "Invalid number of arguments";
+    @_ == 2 or die $ARG_ERROR;
     my ($self, $msg) = @_;
     my $fh = $self->{log};
     print $fh "$msg\n";
@@ -99,7 +101,7 @@ Log provided message with the current timestamp and the name of calling script.
 =cut
 
 sub log_time {
-    @_ == 2 or die "Invalid number of arguments";
+    @_ == 2 or die $ARG_ERROR;
     my ($self, $msg) = @_;
     my $time = strftime('%Y-%m-%d %H:%M:%S', localtime);
     $self->log_msg("######  $msg  $0: $time  ######");
@@ -114,7 +116,7 @@ Log provided message and append content of file.
 =cut
 
 sub log_file {
-    @_ == 3 or die "Invalid number of arguments";
+    @_ == 3 or die $ARG_ERROR;
     my ($self, $msg, $log_file) = @_;
     $self->log_msg($msg);
     open(IN, "<$log_file") or die "Cannot read file to be logged";
@@ -134,8 +136,8 @@ Close log file.
 =cut
 
 sub close {
-    @_ == 1 or die "Invalid number of arguments";
-    my $self = shift;
+    @_ == 1 or die $ARG_ERROR;
+    my ($self) = @_;
     close($self->{log});
 }
 

--- a/framework/core/Project.pm
+++ b/framework/core/Project.pm
@@ -159,7 +159,7 @@ reference to it.
 
 sub create_project {
     @_ == 1 or die "$ARG_ERROR Use: create_project(project_id)";
-    my $pid = shift;
+    my ($pid) = @_;
     my $module = __PACKAGE__ . "/$pid.pm";
     my $class  = __PACKAGE__ . "::$pid";
 
@@ -209,7 +209,8 @@ Prints all general and project-specific properties to STDOUT.
 =cut
 
 sub print_info {
-    my $self = shift;
+    @_ == 1 or die $ARG_ERROR;
+    my ($self) = @_;
     my $pid = $self->{pid};
     print "Summary of configuration for Project: $pid\n";
     print "-"x80 . "\n";
@@ -352,7 +353,8 @@ Checks whether the project is correctly configured.
 =cut
 
 sub sanity_check {
-    my $self = shift;
+    @_ == 1 or die $ARG_ERROR;
+    my ($self) = @_;
     return $self->_ant_call_comp("sanity.check");
 }
 
@@ -959,7 +961,8 @@ Delegate to the L<Vcs> backend.
 =cut
 
 sub num_revision_pairs {
-    my $self = shift;
+    @_ == 1 or die $ARG_ERROR;
+    my ($self) = @_;
     return $self->{_vcs}->num_revision_pairs();
 }
 
@@ -972,7 +975,8 @@ Delegate to the L<Vcs> backend.
 =cut
 
 sub get_bug_ids {
-    my $self = shift;
+    @_ == 1 or die $ARG_ERROR;
+    my ($self) = @_;
     return $self->{_vcs}->get_bug_ids();
 }
 
@@ -1209,7 +1213,8 @@ sub _write_props {
 # Cache the directory-layout map from the project directory, if it exists.
 #
 sub _cache_layout_map {
-    my $self = shift;
+    @_ == 1 or die $ARG_ERROR;
+    my ($self) = @_;
     my $pid = $self->{pid};
     my $map_file = "$PROJECTS_DIR/$pid/$LAYOUT_FILE";
     return unless -e $map_file;

--- a/framework/core/Project.pm
+++ b/framework/core/Project.pm
@@ -47,7 +47,7 @@ A specific project instance can be created with C<create_project(project_id)>.
   my $PID = "MyID";
 
   sub new {
-    my $class = shift;
+    my ($class) = @_;
     my $name  = "my-project-name";
     my $vcs   = Vcs::Git->new($PID,
                               "$REPO_DIR/$name.git",

--- a/framework/core/Project/Lang.pm
+++ b/framework/core/Project/Lang.pm
@@ -72,7 +72,8 @@ sub determine_layout {
 # Existing Ant build.xml and default.properties
 #
 sub _layout1 {
-    my $dir = shift;
+    @_ == 1 or die $ARG_ERROR;
+    my ($dir) = @_;
     my $src  = `grep "source.home" $dir/default.properties 2>/dev/null`;
     my $test = `grep "test.home" $dir/default.properties 2>/dev/null`;
 
@@ -88,7 +89,8 @@ sub _layout1 {
 # Generated build.xml (from mvn ant:ant) with maven-build.properties
 #
 sub _layout2 {
-    my $dir = shift;
+    @_ == 1 or $ARG_ERROR;
+    my ($dir) = @_;
     my $src  = `grep "maven.build.srcDir.0" $dir/maven-build.properties 2>/dev/null`;
     my $test = `grep "maven.build.testDir.0" $dir/maven-build.properties 2>/dev/null`;
 

--- a/framework/core/Project/Math.pm
+++ b/framework/core/Project/Math.pm
@@ -71,7 +71,8 @@ sub determine_layout {
 # Existing Ant build.xml and default.properties
 #
 sub _layout1 {
-    my $dir = shift;
+    @_ == 1 or die $ARG_ERROR;
+    my ($dir) = @_;
     my $src  = `grep 'name="source.home"' $dir/build.xml 2>/dev/null`; chomp $src;
     my $test = `grep 'name="test.home"' $dir/build.xml 2>/dev/null`; chomp $test;
 
@@ -87,7 +88,8 @@ sub _layout1 {
 # Generated build.xml (from mvn ant:ant) with maven-build.properties
 #
 sub _layout2 {
-    my $dir = shift;
+    @_ == 1 or die $ARG_ERROR;
+    my ($dir) = @_;
     my $src  = `grep "<sourceDirectory>" $dir/project.xml 2>/dev/null`; chomp $src;
     my $test = `grep "<unitTestSourceDirectory>" $dir/project.xml 2>/dev/null`; chomp $test;
 

--- a/framework/core/Project/template
+++ b/framework/core/Project/template
@@ -115,7 +115,8 @@ sub initialize_revision {
 # Existing Ant build.xml and default.properties
 #
 sub _ant_layout {
-    my $dir = shift;
+    @_ == 1 or die $ARG_ERROR;
+    my ($dir) = @_;
     my $src  = `grep "source.home" $dir/default.properties 2>/dev/null`;
     my $test = `grep "test.home" $dir/default.properties 2>/dev/null`;
 
@@ -132,7 +133,8 @@ sub _ant_layout {
 # Generated build.xml (from mvn ant:ant) with maven-build.properties
 #
 sub _maven_layout {
-    my $dir = shift;
+    @_ == 1 or die $ARG_ERROR;
+    my ($dir) = @_;
     my $src  = `grep "maven.build.srcDir.0" $dir/maven-build.properties 2>/dev/null`;
     my $test = `grep "maven.build.testDir.0" $dir/maven-build.properties 2>/dev/null`;
 

--- a/framework/core/Utils.pm
+++ b/framework/core/Utils.pm
@@ -99,7 +99,7 @@ The default is L<D4J_TMP_DIR|Constants>.
 sub get_tmp_dir {
     @_ == 1 or die $ARG_ERROR;
     my ($tmp_root) = @_;
-    $tmp_root = $tmp_root // $D4J_TMP_DIR;
+    $tmp_root //= $D4J_TMP_DIR;
     return "$tmp_root/" . basename($0) . "_" . $$ . "_" . time;
 }
 
@@ -327,7 +327,7 @@ C<undef> otherwise.
 sub read_config_file {
     @_ >= 1 or die $ARG_ERROR;
     my ($file, $key_separator) = @_;
-    $key_separator = $key_separator // '=';
+    $key_separator //= '=';
 
     if (!open(IN, "<$file")) {
         print(STDERR "Cannot open config file ($file): $!\n");

--- a/framework/core/Utils.pm
+++ b/framework/core/Utils.pm
@@ -97,7 +97,9 @@ The default is L<D4J_TMP_DIR|Constants>.
 =cut
 
 sub get_tmp_dir {
-    my $tmp_root = shift // $D4J_TMP_DIR;
+    @_ == 1 or die $ARG_ERROR;
+    my ($tmp_root) = @_;
+    $tmp_root = $tmp_root // $D4J_TMP_DIR;
     return "$tmp_root/" . basename($0) . "_" . $$ . "_" . time;
 }
 
@@ -111,7 +113,7 @@ Returns the absolute path to the directory F<dir>.
 
 sub get_abs_path {
     @_ == 1 or die $ARG_ERROR;
-    my $dir = shift;
+    my ($dir) = @_;
     # Remove trailing slash
     $dir =~ s/^(.+)\/$/$1/;
     return abs_path($dir);
@@ -127,7 +129,7 @@ Returns the directory of the absolute path of F<file>.
 
 sub get_dir {
     @_ == 1 or die $ARG_ERROR;
-    my $path = shift;
+    my ($path) = @_;
     my ($volume,$dir,$file) = File::Spec->splitpath($path);
     return get_abs_path($dir);
 }
@@ -324,8 +326,9 @@ C<undef> otherwise.
 
 sub read_config_file {
     @_ >= 1 or die $ARG_ERROR;
-    my $file = shift;
-    my $key_separator = shift // '=';
+    my ($file, $key_separator) = @_;
+    $key_separator = $key_separator // '=';
+
     if (!open(IN, "<$file")) {
         print(STDERR "Cannot open config file ($file): $!\n");
         return undef;
@@ -424,7 +427,7 @@ success, write:
 
 sub check_vid {
     @_ == 1 or die $ARG_ERROR;
-    my $vid = shift;
+    my ($vid) = @_;
     $vid =~ /^(\d+)([bf])$/ or confess("Wrong version_id: $vid -- expected \\d+[bf]!");
     return {valid => 1, bid => $1, type => $2};
 }
@@ -441,8 +444,7 @@ exists and the bug-id both exists in the project and is active.
 
 sub ensure_valid_bid {
     @_ == 2 or die $ARG_ERROR;
-    my $pid = shift;
-    my $bid = shift;
+    my ($pid, $bid) = @_;
 
     my $project_dir = "$PROJECTS_DIR/$pid";
 
@@ -476,8 +478,7 @@ in the project and is active.
 
 sub ensure_valid_vid {
     @_ == 2 or die $ARG_ERROR;
-    my $pid = shift;
-    my $vid = shift;
+    my ($pid, $vid) = @_;
     my $bid = check_vid($vid)->{bid};
     ensure_valid_bid($pid, $bid);
 }
@@ -505,7 +506,7 @@ failing test methods. Returns 0 otherwise.
 
 sub has_failing_tests {
     @_ == 1 or die $ARG_ERROR;
-    my $file_name = shift;
+    my ($file_name) = @_;
 
     my $list = get_failing_tests($file_name) or die "Could not parse file";
     my @fail_methods = @{$list->{methods}};
@@ -535,7 +536,7 @@ C<methods>, and C<asserts>), which map to lists of failing tests:
 
 sub get_failing_tests {
     @_ == 1 or die $ARG_ERROR;
-    my $file_name = shift;
+    my ($file_name) = @_;
 
     my $list = {
         classes => [],

--- a/framework/core/Utils.pm
+++ b/framework/core/Utils.pm
@@ -97,7 +97,6 @@ The default is L<D4J_TMP_DIR|Constants>.
 =cut
 
 sub get_tmp_dir {
-    @_ == 1 or die $ARG_ERROR;
     my ($tmp_root) = @_;
     $tmp_root //= $D4J_TMP_DIR;
     return "$tmp_root/" . basename($0) . "_" . $$ . "_" . time;

--- a/framework/core/Vcs.pm
+++ b/framework/core/Vcs.pm
@@ -205,7 +205,8 @@ Returns the number of revision pairs in the L<BUGS_CSV_ACTIVE|Constants> file.
 =cut
 
 sub num_revision_pairs {
-    my $self = shift;
+    @_ == 1 or die $ARG_ERROR;
+    my ($self) = @_;
     return scalar keys %{$self->{_cache}};
 }
 
@@ -218,7 +219,8 @@ Returns an array of all bug ids in the L<BUGS_CSV_ACTIVE|Constants> file.
 =cut
 
 sub get_bug_ids {
-    my $self = shift;
+    @_ == 1 or die $ARG_ERROR;
+    my ($self) = @_;
     return sort {$a <=> $b} keys %{$self->{_cache}};
 }
 
@@ -431,7 +433,8 @@ sub rev_date {
 # Read the L<BUGS_CSV_ACTIVE|Constants> file and build cache
 #
 sub _build_db_cache {
-    my $db = shift;
+    @_ == 1 or die $ARG_ERROR;
+    my ($db) = @_;
     open (IN, "<$db") or die "Cannot open $BUGS_CSV_ACTIVE $db: $!";
     my $cache = {};
     
@@ -450,7 +453,8 @@ sub _build_db_cache {
 # Truncate revision id to 8 characters if necessary
 #
 sub _trunc_rev_id {
-    my $id = shift;
+    @_ == 1 or die $ARG_ERROR;
+    my ($id) = @_;
     if (length($id) > 8) {
         $id = substr($id, 0, 8);
     }

--- a/framework/test/resources/output/bug-mining/framework/core/Project/TestCodec.pm
+++ b/framework/test/resources/output/bug-mining/framework/core/Project/TestCodec.pm
@@ -115,7 +115,8 @@ sub initialize_revision {
 # Existing Ant build.xml and default.properties
 #
 sub _ant_layout {
-    my $dir = shift;
+    @_ == 1 or die $ARG_ERROR;
+    my ($dir) = @_;
     my $src  = `grep "source.home" $dir/default.properties 2>/dev/null`;
     my $test = `grep "test.home" $dir/default.properties 2>/dev/null`;
 
@@ -132,7 +133,8 @@ sub _ant_layout {
 # Generated build.xml (from mvn ant:ant) with maven-build.properties
 #
 sub _maven_layout {
-    my $dir = shift;
+    @_ == 1 or die $ARG_ERROR;
+    my ($dir) = @_;
     my $src  = `grep "maven.build.srcDir.0" $dir/maven-build.properties 2>/dev/null`;
     my $test = `grep "maven.build.testDir.0" $dir/maven-build.properties 2>/dev/null`;
 

--- a/framework/test/test_gen_tests.sh
+++ b/framework/test/test_gen_tests.sh
@@ -99,28 +99,26 @@ for bid in $(echo $BUGS); do
         suite_dir="$work_dir/$tool/$suite_num"
 
         # Generate (regression) tests for the fixed version
-        for type in f; do
-            vid=${bid}$type
+        vid=${bid}f
 
-            # Run generator and the fix script on the generated test suite
-            if ! gen_tests.pl -g "$tool" -p $PID -v $vid -n 1 -o "$TMP_DIR" -b 30 -c "$target_classes"; then
-                die "run $tool (regression) on $PID-$vid"
-                # Skip any remaining analyses (cannot be run), even if halt-on-error is false
-                continue
-            fi
-            fix_test_suite.pl -p $PID -d "$suite_dir" || die "fix test suite"
+        # Run generator and the fix script on the generated test suite
+        if ! gen_tests.pl -g "$tool" -p $PID -v $vid -n 1 -o "$TMP_DIR" -b 30 -c "$target_classes"; then
+            die "run $tool (regression) on $PID-$vid"
+            # Skip any remaining analyses (cannot be run), even if halt-on-error is false
+            continue
+        fi
+        fix_test_suite.pl -p $PID -d "$suite_dir" || die "fix test suite"
 
-            # Run test suite and determine bug detection
-            test_bug_detection $PID "$suite_dir"
+        # Run test suite and determine bug detection
+        test_bug_detection $PID "$suite_dir"
 
-            # Run test suite and determine mutation score
-            test_mutation $PID "$suite_dir"
+        # Run test suite and determine mutation score
+        test_mutation $PID "$suite_dir"
 
-            # Run test suite and determine code coverage
-            test_coverage $PID "$suite_dir" 0
+        # Run test suite and determine code coverage
+        test_coverage $PID "$suite_dir" 0
 
-            rm -rf $work_dir/$tool
-        done
+        rm -rf $work_dir/$tool
     done
 
     vid=${bid}b


### PR DESCRIPTION
This PR does various tidying changes.

## Subroutine Argument handling
This PR moves away from
```
my $foo = shift;
my $bar = shift;
```
and towards
```
my ($foo, $bar) = @_;
```
wherever possible.

## Useless for loop
I removed a useless loop `for type in f ; do ... done`, which iterates once.

## Uncommented a `DEBUG` check in `framework/bin/run_klocs.pl`
Not sure why this was commented out, and maybe we want to keep it commented, but it seemed like an error.

