### PR TITLE
Try again if download fails

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -137,6 +137,9 @@ RANDOOP_JAR="randoop-all-${RANDOOP_VERSION}.jar"
 REPLACECALL_JAR="replacecall-${RANDOOP_VERSION}.jar"
 COVEREDCLASS_JAR="covered-class-${RANDOOP_VERSION}.jar"
 (cd "$DIR_LIB_GEN" && download_url "$RANDOOP_URL/$RANDOOP_ZIP" \
+                   && unzip -q $RANDOOP_ZIP) \
+ || (cd "$DIR_LIB_GEN" && rm -f $RANDOOP_ZIP \
+                   && download_url "$RANDOOP_URL/$RANDOOP_ZIP" \
                    && unzip -q $RANDOOP_ZIP)
 # Set symlink for the supported version of Randoop
 (cd "$DIR_LIB_GEN" && ln -sf "randoop-${RANDOOP_VERSION}/$RANDOOP_JAR" "randoop-current.jar")


### PR DESCRIPTION
Example failures: https://travis-ci.org/github/rjust/defects4j/jobs/739056941 , https://travis-ci.com/github/mernst/defects4j/jobs/407829098 , https://travis-ci.com/github/mernst/defects4j/jobs/407797430 .
A better solution than the one in this pull request would be to encapsulate the logic in a download_url_and_unzip routine.