### PR TITLE
Fix issue #392

### DIFF
--- a/framework/lib/test_generation/bin/_tool.source
+++ b/framework/lib/test_generation/bin/_tool.source
@@ -68,6 +68,13 @@ get_relevant_classes() {
             export -p classes.relevant -w $D4J_DIR_WORKDIR 2> /dev/null
 }
 
+# Returns the list of all modified classes for the current bug
+get_modified_classes() {
+    local file=$1
+    $D4J_HOME/framework/bin/defects4j \
+            export -p classes.modified -w $D4J_DIR_WORKDIR 2> /dev/null
+}
+
 # Output a command, execute it, and print whether it succeeded or failed.
 exec_cmd() {
     local cmd=$1

--- a/framework/lib/test_generation/bin/_tool.source
+++ b/framework/lib/test_generation/bin/_tool.source
@@ -70,7 +70,6 @@ get_relevant_classes() {
 
 # Returns the list of all modified classes for the current bug
 get_modified_classes() {
-    local file=$1
     $D4J_HOME/framework/bin/defects4j \
             export -p classes.modified -w $D4J_DIR_WORKDIR 2> /dev/null
 }

--- a/framework/lib/test_generation/bin/randoop.sh
+++ b/framework/lib/test_generation/bin/randoop.sh
@@ -34,13 +34,24 @@ project_cp=$(get_project_cp)
 # Read all additional configuration parameters
 add_config=$(parse_config "$D4J_DIR_TESTGEN_BIN/randoop.config")
 
+# If the user provided a custom set of target classes, invoke Randoop with all
+# classes (as opposed to only relevant classes). This will allow Randoop to
+# generate tests for all target classes, but will likely require a larger budget
+# because many classes irrelevant to the target classes will be explored as
+# well.
+get_modified_classes > "$D4J_DIR_WORKDIR/classes.d4j.modified"
+if diff -q -w "$D4J_DIR_WORKDIR/classes.d4j.modified" "$D4J_FILE_TARGET_CLASSES"; then
+    echo "Running Randoop on relevant classes only"
+    get_relevant_classes > "$D4J_DIR_WORKDIR/classes.randoop"
+else
+    echo "Running Randoop on all classes"
+    get_all_classes > "$D4J_DIR_WORKDIR/classes.randoop"
+fi
+
 # Make sure the provided test mode is supported
 if [ "$D4J_TEST_MODE" == "regression" ]; then
-    get_relevant_classes > "$D4J_DIR_WORKDIR/classes.randoop"
     add_config="$add_config --no-error-revealing-tests=true"
 elif [ "$D4J_TEST_MODE" == "error-revealing" ]; then
-    #get_all_classes > "$D4J_DIR_WORKDIR/classes.randoop"
-    get_relevant_classes > "$D4J_DIR_WORKDIR/classes.randoop"
     add_config="$add_config --no-regression-tests=true"
 else
     die "Unsupported test mode: $D4J_TEST_MODE"


### PR DESCRIPTION
If a user provides a custom set of target classes, Defects4J now invokes Randoop on all classes (as opposed to only relevant classes). This allows Randoop to generate tests for all target classes, but will likely require a larger budget because many classes irrelevant to the target class(es) will be explored as well.