### PR TITLE
Revise Cli-5 developer patch

### DIFF
--- a/framework/projects/Cli/patches/5.src.patch
+++ b/framework/projects/Cli/patches/5.src.patch
@@ -6,9 +6,9 @@ index 94e97e3..2d88c30 100644
       */
      static String stripLeadingHyphens(String str)
      {
--        if (str == null) {
--            return null;
--        }
++        if (str == null) {
++            return null;
++        }
          if (str.startsWith("--"))
          {
              return str.substring(2, str.length());


### PR DESCRIPTION
Dear authors,
It seems the authors made a mistake here and reversed the order of the buggy version and the fixed version.
To verify that, you can run defects4j checkout -p Cli -v 5b -w ./ and defects4j checkout -p Cli -v 5f -w ./ to check the true diff.