### PR TITLE
Revise Cli-8 developer patch

### DIFF
--- a/framework/projects/Cli/patches/8.src.patch
+++ b/framework/projects/Cli/patches/8.src.patch
@@ -6,8 +6,8 @@ index 40873f5..639b9d5 100644
          while (true)
          {
              text = padding + text.substring(pos).trim();
--            pos = findWrapPos(text, width, 0);
-+            pos = findWrapPos(text, width, nextLineTabStop);
++            pos = findWrapPos(text, width, 0);
+-            pos = findWrapPos(text, width, nextLineTabStop);
  
              if (pos == -1)
              {


### PR DESCRIPTION
Dear authors,
It seems the authors made a mistake here and reversed the order of the buggy version and the fixed version.
To verify that, you can run defects4j checkout -p Cli -v 8b -w ./ and defects4j checkout -p Cli -v 8f -w ./ to check the true diff.