### PR TITLE
Add having an arbitrary directory as checkout's working directory

### DIFF
--- a/framework/core/Utils.pm
+++ b/framework/core/Utils.pm
@@ -115,7 +115,7 @@ sub get_abs_path {
     my ($dir) = @_;
     # Remove trailing slash
     $dir =~ s/^(.+)\/$/$1/;
-    return abs_path($dir);
+    return File::Spec->rel2abs($dir);
 }
 
 =pod


### PR DESCRIPTION
`abs_path` from the `Cwd` module works fine on existing directories, but its behavior on non-existent directories is inconsistent in different environments. On Linux, running `abs_path('./tmp/lang_1_buggy')` gives desired result only when the parent directory (`tmp`) exists. On Windows, however, the complete tree of directories (both `tmp` and `lang_1_buggy`) should exist for it to work.

Using `rel2abs` from `File::Spec` alleviates this issue and makes it consistent across different environments with any number of non-existing directories given to it. So now

```
defects4j checkout -p Lang -v 1b -w ./tmp/lang_1_buggy
```

works everywhere with `tmp` being present or not.

This also fixes https://github.com/rjust/defects4j/issues/397