### PR TITLE
Add Fenton Reid to defects4j.build.xml

### DIFF
--- a/framework/projects/defects4j.build.xml
+++ b/framework/projects/defects4j.build.xml
@@ -104,7 +104,7 @@ project-specific build file ("project_id"/"project_id".build.xml) for the
     Run developer-written tests
 -->
     <target name="run.dev.tests" depends="compile.tests,update.all.tests" description="Run unit tests">
-        <junit printsummary="yes" haltonfailure="no" haltonerror="no" fork="no" showOutput="true">
+		<junit printsummary="yes" haltonfailure="no" haltonerror="no" fork="on" forkmode="once" showOutput="true" timeout="180000">
             <classpath>
                 <!-- Make sure that instrumented classes appear at the beginning of the
                      classpath -->


### PR DESCRIPTION
The JUnit task for run.dev.tests in defects4j.build.xml has the fork attribute enabled, with fork mode set to 'once' to create a single JVM for all tests.  A default timeout of 3 minutes is also specified, to stop the execution of all tests after this period. 

This change allows for endless execution of relevant tests for the defects4j 'test' command with the -r flag. Without the run.dev.tests task hanging indefinitely, a problem encountered in Dockerized defects4J. 