### PR TITLE
Fix whitespace in git-apply

### DIFF
--- a/framework/core/Vcs.pm
+++ b/framework/core/Vcs.pm
@@ -394,11 +394,11 @@ sub _apply_cmd {
     my @try = (1, 0, 2);
     my $log = "";
     for my $n (@try) {
-        my $cmd = "cd $work_dir; git apply -p$n --check $patch_file 2>&1";
+        my $cmd = "cd $work_dir; git apply -p$n --check $patch_file 2>&1 --whitespace=fix";
         $log .= "* $cmd\n";
         $log .= `$cmd`;
         if ($? == 0) {
-            return("cd $work_dir; git apply -p$n $patch_file 2>&1");
+            return("cd $work_dir; git apply -p$n $patch_file 2>&1 --whitespace=fix");
         }
     }
     confess("Cannot determine how to apply patch!\n" .


### PR DESCRIPTION
Add "--whitespace=fix" parameter to git apply in `defects4j checkout` command.

The patch file can not be applied without this param.

Eg. Error occurred when running `defects4j checkout -p Lang -v 1b -w /tmp/lang_1_buggy`

Env:
MacOS Monterey 12.6.3 or Ubuntu 22.04 LTS
Git version 2.39


```
Checking out 687b2e62 to /Users/pengyu/src/defects4j_repair_Lang_6_buggy... OK
Init local repository...................................................... OK
Tag post-fix revision...................................................... OK
Excluding broken/flaky tests............................................... OK
Excluding broken/flaky tests............................................... OK
Excluding broken/flaky tests............................................... OK
Initialize fixed program version........................................... OK
Cannot determine how to apply patch!
All attempts failed:
* cd /Users/pengyu/src/defects4j_repair_Lang_6_buggy; git apply -p1 --verbose --check /Users/pengyu/src/kth/plm-repair-them-all/benchmarks/defects4j/framework/projects/Lang/patches/1.src.patch 2>&1
Checking patch src/main/java/org/apache/commons/lang3/math/NumberUtils.java...
error: while searching for:
            }
        }
        if (pfxLen > 0) { // we have a hex number
            char firstSigDigit = 0; // strip leading zeroes
            for(int i = pfxLen; i < str.length(); i++) {
                firstSigDigit = str.charAt(i);
                if (firstSigDigit == '0') { // count leading zeroes
                    pfxLen++;
                } else {
                    break;
                }
            }
            final int hexDigits = str.length() - pfxLen;
            if (hexDigits > 16 || (hexDigits == 16 && firstSigDigit > '7')) { // too many for Long
                return createBigInteger(str);
            }
            if (hexDigits > 8 || (hexDigits == 8 && firstSigDigit > '7')) { // too many for an int
                return createLong(str);
            }
            return createInteger(str);

error: patch failed: src/main/java/org/apache/commons/lang3/math/NumberUtils.java:464
error: src/main/java/org/apache/commons/lang3/math/NumberUtils.java: patch does not apply
```

