### PR TITLE
Fix incorrect target name for Math 99

### DIFF
--- a/framework/projects/Math/patches/99.test.patch
+++ b/framework/projects/Math/patches/99.test.patch
@@ -1,4 +1,4 @@
-diff --git a/src/test/org/apache/commons/math/util/MathUtilsTest.java b/org/apache/commons/math/util/MathUtilsTest.java
+diff --git a/src/test/org/apache/commons/math/util/MathUtilsTest.java b/src/test/org/apache/commons/math/util/MathUtilsTest.java
 index 20b61df..26433d6 100644
 --- a/src/test/org/apache/commons/math/util/MathUtilsTest.java
 +++ b/src/test/org/apache/commons/math/util/MathUtilsTest.java

--- a/framework/projects/Math/patches/99.test.patch
+++ b/framework/projects/Math/patches/99.test.patch
@@ -1,7 +1,7 @@
 diff --git a/src/test/org/apache/commons/math/util/MathUtilsTest.java b/org/apache/commons/math/util/MathUtilsTest.java
 index 20b61df..26433d6 100644
 --- a/src/test/org/apache/commons/math/util/MathUtilsTest.java
-+++ b/src/test/org/apache/commons/math/util/MathUtilsTest.java
++++ b/org/apache/commons/math/util/MathUtilsTest.java
 @@ -429,28 +429,12 @@ public final class MathUtilsTest extends TestCase {
          assertEquals(3 * (1<<15), MathUtils.gcd(3 * (1<<20), 9 * (1<<15)));
  

--- a/framework/projects/Math/patches/99.test.patch
+++ b/framework/projects/Math/patches/99.test.patch
@@ -1,7 +1,7 @@
 diff --git a/src/test/org/apache/commons/math/util/MathUtilsTest.java b/org/apache/commons/math/util/MathUtilsTest.java
 index 20b61df..26433d6 100644
 --- a/src/test/org/apache/commons/math/util/MathUtilsTest.java
-+++ b/org/apache/commons/math/util/MathUtilsTest.java
++++ b/src/test/org/apache/commons/math/util/MathUtilsTest.java
 @@ -429,28 +429,12 @@ public final class MathUtilsTest extends TestCase {
          assertEquals(3 * (1<<15), MathUtils.gcd(3 * (1<<20), 9 * (1<<15)));
  


### PR DESCRIPTION
The diff target file specified after `index 20b61df..26433d6 100644` (`b/src/test/org/apache/commons/math/util/MathUtilsTest.java`) doesn't match the file's header diff target (`b/org/apache/commons/math/util/MathUtilsTest.java`, causing an error when parsing the patch automatically (e.g., [unidiff](https://pypi.org/project/unidiff/).

This PR replaces with diff target file with the header's.