### PR TITLE
Add missing test patches

### DIFF
--- a/framework/projects/Chart/patches/10.test.patch
+++ b/framework/projects/Chart/patches/10.test.patch
@@ -1,0 +1,4 @@
+This empty diff is generated automatically because the tests for this bug do not change.
+--- /dev/null
++++ /dev/null
+ 

--- a/framework/projects/Chart/patches/13.test.patch
+++ b/framework/projects/Chart/patches/13.test.patch
@@ -1,0 +1,4 @@
+This empty diff is generated automatically because the tests for this bug do not change.
+--- /dev/null
++++ /dev/null
+ 

--- a/framework/projects/Chart/patches/26.test.patch
+++ b/framework/projects/Chart/patches/26.test.patch
@@ -1,0 +1,4 @@
+This empty diff is generated automatically because the tests for this bug do not change.
+--- /dev/null
++++ /dev/null
+ 

--- a/framework/projects/Chart/patches/4.test.patch
+++ b/framework/projects/Chart/patches/4.test.patch
@@ -1,0 +1,4 @@
+This empty diff is generated automatically because the tests for this bug do not change.
+--- /dev/null
++++ /dev/null
+ 

--- a/framework/projects/Chart/patches/7.test.patch
+++ b/framework/projects/Chart/patches/7.test.patch
@@ -1,0 +1,4 @@
+This empty diff is generated automatically because the tests for this bug do not change.
+--- /dev/null
++++ /dev/null
+ 

--- a/framework/projects/Chart/patches/8.test.patch
+++ b/framework/projects/Chart/patches/8.test.patch
@@ -1,0 +1,4 @@
+This empty diff is generated automatically because the tests for this bug do not change.
+--- /dev/null
++++ /dev/null
+ 

--- a/framework/projects/Chart/patches/9.test.patch
+++ b/framework/projects/Chart/patches/9.test.patch
@@ -1,0 +1,4 @@
+This empty diff is generated automatically because the tests for this bug do not change.
+--- /dev/null
++++ /dev/null
+ 

--- a/framework/projects/Lang/patches/15.test.patch
+++ b/framework/projects/Lang/patches/15.test.patch
@@ -1,0 +1,4 @@
+This empty diff is generated automatically because the tests for this bug do not change.
+--- /dev/null
++++ /dev/null
+ 

--- a/framework/projects/Lang/patches/25.test.patch
+++ b/framework/projects/Lang/patches/25.test.patch
@@ -1,0 +1,4 @@
+This empty diff is generated automatically because the tests for this bug do not change.
+--- /dev/null
++++ /dev/null
+ 

--- a/framework/projects/Lang/patches/49.test.patch
+++ b/framework/projects/Lang/patches/49.test.patch
@@ -1,0 +1,4 @@
+This empty diff is generated automatically because the tests for this bug do not change.
+--- /dev/null
++++ /dev/null
+ 

--- a/framework/projects/Mockito/patches/1.test.patch
+++ b/framework/projects/Mockito/patches/1.test.patch
@@ -1,0 +1,4 @@
+This empty diff is generated automatically because the tests for this bug do not change.
+--- /dev/null
++++ /dev/null
+ 

--- a/framework/projects/Mockito/patches/20.test.patch
+++ b/framework/projects/Mockito/patches/20.test.patch
@@ -1,0 +1,4 @@
+This empty diff is generated automatically because the tests for this bug do not change.
+--- /dev/null
++++ /dev/null
+ 

--- a/framework/projects/Mockito/patches/3.test.patch
+++ b/framework/projects/Mockito/patches/3.test.patch
@@ -1,0 +1,4 @@
+This empty diff is generated automatically because the tests for this bug do not change.
+--- /dev/null
++++ /dev/null
+ 

--- a/framework/projects/Time/patches/1.test.patch
+++ b/framework/projects/Time/patches/1.test.patch
@@ -1,0 +1,4 @@
+This empty diff is generated automatically because the tests for this bug do not change.
+--- /dev/null
++++ /dev/null
+ 


### PR DESCRIPTION
This PR addresses #512 by adding empty test patches when missing.

I validated the format of the empty diffs by running `diffstat` and verifying that the tool terminates without crashing and displaying `0 files changed` as output.

I wrote a Python script to generate these files automatically. I can include it in this PR if it would be useful to the project (one might adapt the script to verify that contributors do not add a src patch file without a test patch file).