### PR TITLE
update JacksonDatabind test for newer versions of JDK 8

### DIFF
--- a/framework/core/Project/JacksonDatabind.pm
+++ b/framework/core/Project/JacksonDatabind.pm
@@ -63,6 +63,21 @@ sub new {
 #
 sub _post_checkout {
     my ($self, $rev_id, $work_dir) = @_;
+    my $vid = $self->{_vcs}->lookup_vid($rev_id);
+
+    # Fix compilation errors if necessary
+    my $compile_errors = "$PROJECTS_DIR/$self->{pid}/compile-errors/";
+    opendir(DIR, $compile_errors) or die "Could not find compile-errors directory.";
+    my @entries = readdir(DIR);
+    closedir(DIR);
+    foreach my $file (@entries) {
+        if ($file =~ /-(\d+)-(\d+).diff/) {
+            if ($vid >= $1 && $vid <= $2) {
+                $self->apply_patch($work_dir, "$compile_errors/$file")
+                        or confess("Couldn't apply patch ($file): $!");
+            }
+        }
+    }
 
     my $project_dir = "$PROJECTS_DIR/$self->{pid}";
     # Check whether ant build file exists

--- a/framework/projects/JacksonDatabind/compile-errors/test-111-112.diff
+++ b/framework/projects/JacksonDatabind/compile-errors/test-111-112.diff
@@ -1,0 +1,13 @@
+diff --git a/src/test/java/com/fasterxml/jackson/databind/interop/IllegalTypesCheckTest.java b/src/test/java/com/fasterxml/jackson/databind/interop/IllegalTypesCheckTest.java
+index f7d1517ed..0fc5e357d 100644
+--- a/src/test/java/com/fasterxml/jackson/databind/interop/IllegalTypesCheckTest.java
++++ b/src/test/java/com/fasterxml/jackson/databind/interop/IllegalTypesCheckTest.java
+@@ -80,7 +80,7 @@ public class IllegalTypesCheckTest extends BaseMapTest
+     public void testJDKTypes1855() throws Exception
+     {
+         // apparently included by JDK?
+-        _testIllegalType("com.sun.org.apache.bcel.internal.util.ClassLoader");
++//        _testIllegalType("com.sun.org.apache.bcel.internal.util.ClassLoader");
+ 
+         // also: we can try some form of testing, even if bit contrived...
+         _testIllegalType(BogusPointcutAdvisor.class);

--- a/framework/projects/JacksonDatabind/compile-errors/test-93-97.diff
+++ b/framework/projects/JacksonDatabind/compile-errors/test-93-97.diff
@@ -1,0 +1,13 @@
+diff --git a/src/test/java/com/fasterxml/jackson/databind/interop/IllegalTypesCheckTest.java b/src/test/java/com/fasterxml/jackson/databind/interop/IllegalTypesCheckTest.java
+index f7d1517ed..0fc5e357d 100644
+--- a/src/test/java/com/fasterxml/jackson/databind/interop/IllegalTypesCheckTest.java
++++ b/src/test/java/com/fasterxml/jackson/databind/interop/IllegalTypesCheckTest.java
+@@ -80,7 +80,7 @@ public class IllegalTypesCheckTest extends BaseMapTest
+     public void testJDKTypes1855() throws Exception
+     {
+         // apparently included by JDK?
+-        _testIllegalType("com.sun.org.apache.bcel.internal.util.ClassLoader");
++//        _testIllegalType("com.sun.org.apache.bcel.internal.util.ClassLoader");
+ 
+         // also: we can try some form of testing, even if bit contrived...
+         _testIllegalType(BogusPointcutAdvisor.class);

--- a/framework/projects/JacksonDatabind/compile-errors/test-99-109.diff
+++ b/framework/projects/JacksonDatabind/compile-errors/test-99-109.diff
@@ -1,0 +1,13 @@
+diff --git a/src/test/java/com/fasterxml/jackson/databind/interop/IllegalTypesCheckTest.java b/src/test/java/com/fasterxml/jackson/databind/interop/IllegalTypesCheckTest.java
+index f7d1517ed..0fc5e357d 100644
+--- a/src/test/java/com/fasterxml/jackson/databind/interop/IllegalTypesCheckTest.java
++++ b/src/test/java/com/fasterxml/jackson/databind/interop/IllegalTypesCheckTest.java
+@@ -80,7 +80,7 @@ public class IllegalTypesCheckTest extends BaseMapTest
+     public void testJDKTypes1855() throws Exception
+     {
+         // apparently included by JDK?
+-        _testIllegalType("com.sun.org.apache.bcel.internal.util.ClassLoader");
++//        _testIllegalType("com.sun.org.apache.bcel.internal.util.ClassLoader");
+ 
+         // also: we can try some form of testing, even if bit contrived...
+         _testIllegalType(BogusPointcutAdvisor.class);


### PR DESCRIPTION
Newer versions of JDK 8 no longer contain com.sun.org.apache.bcel.internal.util.ClassLoader.  This pull request adds code to comment out a reference to this item in the testJDKTypes1855 method of IllegalTypesCheckTest.java.