### PR TITLE
Prevent duplicating active_bugs.csv header (#474)

### DIFF
--- a/framework/bug-mining/initialize-project-and-collect-issues.pl
+++ b/framework/bug-mining/initialize-project-and-collect-issues.pl
@@ -182,9 +182,6 @@ if (-e "$CORE_DIR/Project/$PID.pm") {
     system("tail -n +2 $PROJECTS_DIR/$PID/$BUGS_CSV_ACTIVE | cut -f 2- -d',' > $COMMIT_DB_FILE.orig");
     # Find all versions that have not been mined
     system("grep -vFf $COMMIT_DB_FILE.orig $COMMIT_DB_FILE > $COMMIT_DB_FILE.filter && mv $COMMIT_DB_FILE.filter $COMMIT_DB_FILE");
-    # Print header to the active bugs csv
-    my $active_header = $BUGS_CSV_BUGID.",".$BUGS_CSV_COMMIT_BUGGY.",".$BUGS_CSV_COMMIT_FIXED.",".$BUGS_CSV_ISSUE_ID.",".$BUGS_CSV_ISSUE_URL;
-    system("echo $active_header > $COMMIT_DB_FILE.new && cat $COMMIT_DB_FILE >> $COMMIT_DB_FILE.new && mv $COMMIT_DB_FILE.new $COMMIT_DB_FILE");
 }
 
 print("Project $PID has been successfully initialized!\n");


### PR DESCRIPTION
If a project has already been promoted to the main Defects4J database, `if (-e "$CORE_DIR/Project/$PID.pm") {` evaluates to true at `initialize-project-and-collect-issues.pl:180`, `active_bugs.csv` ends up with a duplicated header: one from the just mined bugs (`$COMMIT_DB_FILE`) and the other from the complement computed by `grep -vFf $COMMIT_DB_FILE.orig $COMMIT_DB_FILE`, since `$COMMIT_DB_FILE.orig` lacks such header.