### PR TITLE
Update Dockerfile to Java 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN \
   apt-get update -y && \
   apt-get install software-properties-common -y && \
   apt-get update -y && \
-  apt-get install -y openjdk-8-jdk \
+  apt-get install -y openjdk-11-jdk \
                 git \
                 build-essential \
                 subversion \
@@ -23,7 +23,7 @@ RUN \
   rm -rf /var/lib/apt/lists/*
 
 # Java version
-ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
+ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-amd64
 
 # Timezone
 ENV TZ=America/Los_Angeles


### PR DESCRIPTION
This Pull Request updates the Dockerfile image to use Java 11, following the previous PR for Java 11 compatibility: https://github.com/rjust/defects4j/pull/613.