### PR TITLE
Fixed Chart.build.xml

### DIFF
--- a/framework/projects/Chart/Chart.build.xml
+++ b/framework/projects/Chart/Chart.build.xml
@@ -53,6 +53,7 @@ of the checked-out project version.
                destdir="${d4j.workdir}/build"
                debug="on"
                deprecation="false"
+               encoding="UTF-8"
                source="1.6"
                target="1.6">
             <classpath refid="build.classpath" />
@@ -102,6 +103,7 @@ of the checked-out project version.
                destdir="${d4j.workdir}/build"
                debug="on"
                deprecation="false"
+               encoding="UTF-8"
                source="1.6"
                target="1.6">
             <classpath refid="build.experimental.classpath" />
@@ -116,6 +118,7 @@ of the checked-out project version.
          <mkdir dir="${d4j.workdir}/build-tests"/>
         <javac srcdir="${d4j.workdir}/tests"
                destdir="${d4j.workdir}/build-tests"
+               encoding="UTF-8"
                source="1.6"
                target="1.6"
                debug="true"


### PR DESCRIPTION
Hi,

When trying to run `defects4j` on `Chart 1`, it raised the following error:

```bash
compile:
    [mkdir] Created dir: /tmp/Chart_2/build
    [javac] /defects4j/framework/projects/Chart/Chart.build.xml:57: warning: 'includeantruntime' was not set, defaulting to build.sysclasspath=last; set to false for repeatable builds
    [javac] Compiling 654 source files to /tmp/Chart_2/build
    [javac] warning: [options] bootstrap class path not set in conjunction with -source 6
    [javac] warning: [options] source value 6 is obsolete and will be removed in a future release
    [javac] warning: [options] target value 1.6 is obsolete and will be removed in a future release
    [javac] warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.
    [javac] /tmp/Chart_2/source/org/jfree/chart/axis/Axis.java:1152: error: unmappable character (0xC2) for encoding US-ASCII
    [javac]             return;  // no need to create entity if we can??t save it anyways...
    [javac]                                                           ^
    [javac] /tmp/Chart_2/source/org/jfree/chart/axis/Axis.java:1152: error: unmappable character (0xB4) for encoding US-ASCII
    [javac]             return;  // no need to create entity if we can??t save it anyways...
    [javac]                                                            ^
    [javac] 2 errors
    [javac] 4 warnings

BUILD FAILED
/defects4j/framework/projects/Chart/Chart.build.xml:57: Compile failed; see the compiler error output for details.
```

Adding `encoding="UTF-8"` to the compilation should address the issue.