### PR TITLE
add missing instruction for Perl dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Steps to set up Defects4J
 2. Initialize Defects4J (download the project repositories and external libraries, which are not included in the git repository for size purposes and to avoid redundancies):
     - `cd defects4j`
     - `cpanm --installdeps .`
+    - export PERL5LIB=~/perl5/lib/perl5/ # enable Perl to find all modules
     - `./init.sh`
 
 3. Add Defects4J's executables to your PATH:


### PR DESCRIPTION
Would have saved me 10 minutes.

`export PERL5LIB=~/perl5/lib/perl5/` Fix

```
Can't locate String/Interpolate.pm in @INC (you may need to install the String::Interpolate module) (@INC contains: /mnt/data/martin/defects4j/framework/lib /mnt/data/m
artin/defects4j/framework /mnt/data/martin/defects4j/framework/core /mnt/data/martin/defects4j/framework/core /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.30.0 /usr
/local/share/perl/5.30.0 /usr/lib/x86_64-linux-gnu/perl5/5.30 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl/5.30 /usr/share/perl/5.30 /usr/local/lib/site_perl /usr/li
b/x86_64-linux-gnu/perl-base) at /mnt/data/martin/defects4j/framework/core/Utils.pm line 45.                                                                            
BEGIN failed--compilation aborted at /mnt/data/martin/defects4j/framework/core/Utils.pm line 45.                                                                        
Compilation failed in require at /mnt/data/martin/defects4j/framework/bin/defects4j line 34.                                                                            
BEGIN failed--compilation aborted at /mnt/data/martin/defects4j/framework/bin/defects4j line 34.        

```
 