### PR TITLE
Adds support for both class-level and method-level test execution

### DIFF
--- a/framework/projects/defects4j.build.xml
+++ b/framework/projects/defects4j.build.xml
@@ -105,6 +105,21 @@ project-specific build file ("project_id"/"project_id".build.xml) for the
     Run developer-written tests
 -->
     <target name="run.dev.tests" depends="compile.tests,update.all.tests" description="Run unit tests">
+        <condition property="run.test.with.method">
+            <and>
+                <isset property="test.entry.class"/>
+                <isset property="test.entry.method"/>
+            </and>
+        </condition>
+
+        <condition property="run.test.without.method">
+            <and>
+                <isset property="test.entry.class"/>
+                <not>
+                    <isset property="test.entry.method"/>
+                </not>
+            </and>
+        </condition>
         <junit printsummary="yes" haltonfailure="no" haltonerror="no" fork="no" showOutput="true">
             <classpath>
                 <!-- Make sure that instrumented classes appear at the beginning of the
@@ -117,7 +132,13 @@ project-specific build file ("project_id"/"project_id".build.xml) for the
 
             <sysproperty key="OUTFILE" value="${OUTFILE}"/>
             <formatter classname="edu.washington.cs.mut.testrunner.Formatter" usefile="false" />
-            <test name="${test.entry.class}" methods="${test.entry.method}" if="test.entry.class" />
+            <!-- Usage Case 1: test class and method both specified -->
+            <test name="${test.entry.class}" methods="${test.entry.method}"
+                  if="run.test.with.method" />
+
+            <!-- Usage Case 2: only test class specified -->
+            <test name="${test.entry.class}"
+                  if="run.test.without.method" />
             <batchtest unless="test.entry.class">
                 <fileset refid="all.manual.tests" />
             </batchtest>


### PR DESCRIPTION
## Make test method specification optional in Ant-based test execution
[![Run CI tests](https://github.com/qinfendeheichi/defects4j/actions/workflows/ci.yml/badge.svg)](https://github.com/qinfendeheichi/defects4j/actions/workflows/ci.yml)

### Problem

As discussed in https://github.com/rjust/defects4j/issues/480#issuecomment-1751824775, the current implementation of Defects4j does not support running a specific test class without specifying a test case method. The possible workaround may not be easily integrated with the overall infrastructure.


### Solution

This patch introduces two conditional properties in `defects4j.build.xml` file:

```xml
<condition property="run.test.with.method">
    <and>
        <isset property="test.entry.class"/>
        <isset property="test.entry.method"/>
    </and>
</condition>

<condition property="run.test.without.method">
    <and>
        <isset property="test.entry.class"/>
        <not>
            <isset property="test.entry.method"/>
        </not>
    </and>
</condition>
```
Then, it defines two <test> elements conditionally:

```xml
<!-- Case 1: class and method specified -->
<test name="${test.entry.class}" methods="${test.entry.method}" if="run.test.with.method" />

<!-- Case 2: only class specified -->
<test name="${test.entry.class}" if="run.test.without.method" />
```
The enhancement supports both testClass::testMethod and testClass style test execution. 
### Example Usage

```
Defects4j coverage -t org.example.MyTest org.apache.commons.math3.analysis.integration.gauss.HermiteParametricTest
```



